### PR TITLE
Fix Makefile for Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ PATHSEP = $(strip $(SEP))
 ROOTOUTDIR = $(ROOT_DIR)build
 CPPDIR = $(ROOT_DIR)cpp
 HEADERSDIR = $(ROOT_DIR)include
+AR ?= ar
 
 CXXFLAGS = -g -fPIC -std=c++11 -I.$(PATHSEP)include -I.$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP) -I.$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP) -L.$(PATHSEP)sdk-c$(PATHSEP)build
 LDFLAGS = -lkuzzlesdk
@@ -64,7 +65,7 @@ make_c_sdk:
 
 cpp: export GOPATH = $(ROOT_DIR)go
 cpp: makedir update_submodule make_c_sdk $(CPPSDK)
-		ar rvs $(ROOTOUTDIR)$(PATHSEP)libkuzzlesdk$(STATICLIB) src$(PATHSEP)*.o
+		$(AR) rvs $(ROOTOUTDIR)$(PATHSEP)libkuzzlesdk$(STATICLIB) src$(PATHSEP)*.o
 		$(CXX) -shared -fPIC -o $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB) -Wl,--whole-archive $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB) sdk-c$(PATHSEP)build$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB) -Wl,--no-whole-archive
 		cd $(ROOTOUTDIR) && mv $(LIB_PREFIX)kuzzlesdk$(STATICLIB) $(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION) && mv $(LIB_PREFIX)kuzzlesdk$(DYNLIB) $(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION)
 		cd $(ROOTOUTDIR) && ln -sr $(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(LIB_PREFIX)kuzzlesdk$(DYNLIB)


### PR DESCRIPTION
:warning: Don't this PR yourself :warning:
Depends on [#10](https://github.com/kuzzleio/sdk-c/pull/10)

## What does this PR do ?
Fix Makefile for android builds using environment variables for compilation toolchain tools such as CXX, CC, STRIP, AR ...

