### PR TITLE
Add script to align submodule on branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,20 @@
-# How to contribute to Kuzzle CPP SDK
+# How to contribute to the CPP SDK
 
-Here are a few rules and guidelines to follow if you want to contribute to Kuzzle CPP SDK and, more importantly, if you want to see your pull requests accepted by Kuzzle team.    
+Here are a few rules and guidelines to follow if you want to contribute to the CPP SDK and, more importantly, if you want to see your pull requests accepted by Kuzzle team.
 
-## Run tests
+## Tools
+
+We use git submodules to link the sdk-go and the sdk-c.  
+When you are developing a new functionality that had implications on the other SDK, you should align all your submodules on your development branch.  
+You can use `align-submodules.sh` script to achieve this. (Eg: `./align-submodules.sh 1-dev` to align all submodules on `1-dev` branch)
+
+
+To build the SDK, you can use this Docker image to build the SDK:  
+```
+docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make all
+```
+
+## Running Tests
 
 The tests uses cucumber, so please ensure that you have ruby in your PATH.
 First make the SDK, install `Bundler`, install cucumber and run a Kuzzle stack.  
@@ -21,4 +33,11 @@ Then run features tests
 
 # Run only one feature file
 ./run-functional-testing.sh collection.feature
+
+```
+
+You can also use the Docker container:
+```bash
+# Run all features tests
+docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make build_test run_test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,23 @@
 # How to contribute to the CPP SDK
 
-Here are a few rules and guidelines to follow if you want to contribute to the CPP SDK and, more importantly, if you want to see your pull requests accepted by Kuzzle team.
+Here are a few rules and guidelines to follow if you want to contribute to the Java SDK and, more importantly, if you want to see your pull requests accepted by the  Kuzzle team.
 
 ## Tools
 
-We use git submodules to link the sdk-go and the sdk-c.  
-When you are developing a new functionality that had implications on the other SDK, you should align all your submodules on your development branch.  
-You can use `align-submodules.sh` script to achieve this. (Eg: `./align-submodules.sh 1-dev` to align all submodules on `1-dev` branch)
+This SDK inherits from the following repositories, linked as git submodules: sdk-c, sdk-go.  
+Whenever significant changes are applied to the parent SDKs, you need to align the linked submodules accordingly.
+You can use `align-submodules.sh` script to achieve this. (e.g.: `./align-submodules.sh 1-dev` to align all submodules on `1-dev` branch)
 
 
-To build the SDK, you can use this Docker image to build the SDK:  
+You can use this Docker image to build the SDK:  
 ```
 docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make all
 ```
 
 ## Running Tests
 
-The tests uses cucumber, so please ensure that you have ruby in your PATH.
-First make the SDK, install `Bundler`, install cucumber and run a Kuzzle stack.  
+Tests are handled by [cucumber](https://cucumber.io/).  
+First build the SDK, install `Bundler`, install cucumber and run a Kuzzle stack:
 
 ```bash
 gem install bundler
@@ -29,10 +29,10 @@ bundle install
 Then run features tests
 ```bash
 # Run all features tests
-./run-functionnal-testing.sh
+./run-tests.sh
 
 # Run only one feature file
-./run-functional-testing.sh collection.feature
+./run-tests.sh collection.feature
 
 ```
 

--- a/align-submodules.sh
+++ b/align-submodules.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+BLUE='\033[0;34m'
+LBLUE='\033[1;34m'
+NC='\033[0m'
+
+echo "Align all submodule to the same branch as the current repository."
+echo "You can specify an other branch by passing it as an argument:"
+echo "  ./align-submodules.sh 1-dev"
+echo ""
+
+if [ -z "$1" ]; then
+  git_branch=$(git branch | grep \* | cut -d ' ' -f2)
+else
+  git_branch="$1"
+fi
+
+current_path=$(pwd)
+
+sdk_paths="sdk-c go/src/github.com/kuzzleio/sdk-go"
+
+echo -e "${BLUE}Align submodules on branch $git_branch $NC"
+
+for sdk_path in $sdk_paths;
+do
+  echo -e "${LBLUE}Align $sdk_path $NC"
+  cd $sdk_path
+  git fetch origin $git_branch
+  git checkout $git_branch
+  git pull origin $git_branch
+done
+
+cd $pwd


### PR DESCRIPTION
## What does this PR do ?

This PR add a script to align all submodules on the same branch.  

### How should this be manually tested?

```
# Align submodules on the current branch name
./align-submodules.sh
# Align submodules on 1-dev branch
./align-submodules.sh 1-dev
```

### Other changes

 - update contributing
