### PR TITLE
KZL-547 - Update validateSpecifications signature to take index and collection

### DIFF
--- a/include/collection.hpp
+++ b/include/collection.hpp
@@ -38,8 +38,8 @@ namespace kuzzleio {
             void updateMapping(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
             std::string getSpecifications(const std::string& index, const std::string& collection, query_options *options=nullptr);
             search_result* searchSpecifications(query_options *options=nullptr);
-            std::string updateSpecifications(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            validation_response* validateSpecifications(const std::string& body, query_options *options=nullptr);
+            std::string updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options=nullptr);
+            validation_response* validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options=nullptr);
             void deleteSpecifications(const std::string& index, const std::string& collection, query_options *options=nullptr);
     };
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -111,8 +111,8 @@ namespace kuzzleio {
         return r;
     }
 
-    std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_collection_update_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
+    std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
+        string_result *r = kuzzle_collection_update_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options);
         if (r->error != nullptr)
             throwExceptionFromStatus(r);
         std::string ret = r->result;
@@ -121,8 +121,8 @@ namespace kuzzleio {
         return ret;
     }
 
-    validation_response* Collection::validateSpecifications(const std::string& body, query_options *options) {
-        validation_response *r = kuzzle_collection_validate_specifications(_collection, const_cast<char*>(body.c_str()), options);
+    validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
+        validation_response *r = kuzzle_collection_validate_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options);
         if (r->error != nullptr)
             throwExceptionFromStatus(r);
 

--- a/test/features/step_definitions/collection-steps.cpp
+++ b/test/features/step_definitions/collection-steps.cpp
@@ -164,7 +164,7 @@ namespace {
 
     string specifications = "{\"" + ctx->index + "\":{\"" + collection_id + "\":{\"strict\":true}}}";
 
-    kuzzleio::validation_response *validationResponse = ctx->kuzzle->collection->validateSpecifications(specifications);
+    kuzzleio::validation_response *validationResponse = ctx->kuzzle->collection->validateSpecifications(ctx->index, ctx->collection, specifications);
     ctx->success = validationResponse->valid;
   }
 


### PR DESCRIPTION
## What does this PR do?

Before the method `validateSpecifications` didn't take an index an a collection in parameters and could be used for any collection.  
This PR change the signature to match the rest of the collection controller. The method now take an index and a collection in addition to the specifications for this collection.

I also modify the `updateSpecifications` method. The method was taking an index and collection in parameter but it didn't scope the specifications to the collection. 

Related PR: https://github.com/kuzzleio/sdk-javascript/pull/318, https://github.com/kuzzleio/sdk-go/pull/211, https://github.com/kuzzleio/sdk-c/pull/13, https://github.com/kuzzleio/sdk-cpp/pull/11, https://github.com/kuzzleio/sdk-java/pull/13, https://github.com/kuzzleio/documentation-V2/pull/51
### How should this be manually tested?

  - Step 1: Run Kuzzle Stack `./.ci/start_kuzzle.sh`
  - Step 2: Run tests: `docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make all build_test run_test`