### PR TITLE
[ci] Change the name of S3 deployed artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ install:
 before_script:
   - ./.ci/start_kuzzle.sh
 
+before_deploy:
+  - |
+    if [[ $TRAVIS_BRANCH =~ ^.?-dev$ ]]; then
+      mv ./deploy/kuzzlesdk-cpp-$ARCH-*.tar.gz ./deploy/kuzzlesdk-cpp-$ARCH.tar.gz;
+    fi;
+
 deploy:
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 os: linux
-language: cpp
+language: minimal
 sudo: required
+
+addons:
+  apt:
+    packages:
+    - python
+    - python-pip
 
 services:
   - docker
@@ -20,12 +26,6 @@ stages:
 before_install:
   - sudo sysctl -w vm.max_map_count=262144
 
-addons:
-  apt:
-    packages:
-    - python
-    - python-pip
-
 install:
   - pip install awscli --upgrade --user
 
@@ -35,7 +35,7 @@ before_script:
 before_deploy:
   - |
     if [[ $TRAVIS_BRANCH =~ ^.?-dev$ ]]; then
-      mv ./deploy/kuzzlesdk-*-$ARCH.tar.gz ./deploy/kuzzlesdk-$ARCH-experimental.tar.gz;
+      sudo mv ./deploy/kuzzlesdk-*-$ARCH.tar.gz ./deploy/kuzzlesdk-$ARCH-experimental.tar.gz;
     fi;
 
 deploy:
@@ -63,11 +63,15 @@ jobs:
 # ---------------------------------------
     - stage: Builds & Tests
       name: "Build & Tests using GCC/G++ - amd64"
+
+      env:
+        - ARCH=amd64
+
       script:
         # Build & Test
         - docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make all build_test run_test
 
-      before_deploy:
+      after_success:
         - docker run --rm -it -e ARCH=amd64 -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make package
 # ---------------------------------------
 # I386
@@ -75,11 +79,14 @@ jobs:
     - stage: Builds & Tests
       name: "Build & Tests using GCC/G++ - i386"
 
+      env:
+        - ARCH=i386
+
       script:
         # Build & Test
         - docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-i386 make all build_test run_test
 
-      before_deploy:
+      after_success:
         - docker run --rm -it -e ARCH=i386 -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-i386 make package
 
 # ---------------------------------------
@@ -88,6 +95,9 @@ jobs:
     - stage: Builds & Tests
       name: "Build & Tests using GCC/G++ - armhf"
 
+      env:
+        - ARCH=armhf
+
       script:
         # Build
         - docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-armhf make all build_test
@@ -95,7 +105,7 @@ jobs:
         - docker run --rm --privileged multiarch/qemu-user-static:register
         - docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:armhf-cpp-runner make run_test
 
-      before_deploy:
+      after_success:
         - docker run --rm -it -e ARCH=armhf -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-armhf make package
 
 # ---------------------------------------
@@ -104,6 +114,9 @@ jobs:
     - stage: Builds & Tests
       name: "Build & Tests using GCC/G++ - aarch64"
 
+      env:
+        - ARCH=aarch64
+
       script:
         # Build
         - docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-aarch64 make all build_test
@@ -111,7 +124,7 @@ jobs:
         - docker run --rm --privileged multiarch/qemu-user-static:register
         - docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:aarch64-cpp-runner make run_test
 
-      before_deploy:
+      after_success:
         - docker run --rm -it -e ARCH=aarch64 -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-aarch64 make package
 
 # ---------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 before_deploy:
   - |
     if [[ $TRAVIS_BRANCH =~ ^.?-dev$ ]]; then
-      mv ./deploy/kuzzlesdk-cpp-$ARCH-*.tar.gz ./deploy/kuzzlesdk-cpp-$ARCH.tar.gz;
+      mv ./deploy/kuzzlesdk-*-$ARCH.tar.gz ./deploy/kuzzlesdk-$ARCH-experimental.tar.gz;
     fi;
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ package: $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(ROO
 	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP)sdk_wrappers_internal.h $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOTOUTDIR)$(PATHSEP)*.so  $(ROOTOUTDIR)$(PATHSEP)lib
 	cp $(ROOTOUTDIR)$(PATHSEP)*.a  $(ROOTOUTDIR)$(PATHSEP)lib
-	mkdir deploy && cd $(ROOTOUTDIR) && tar cfz ..$(PATHSEP)deploy$(PATHSEP)kuzzlesdk-cpp-$(ARCH)-$(VERSION).tar.gz lib include
+	mkdir deploy && cd $(ROOTOUTDIR) && tar cfz ..$(PATHSEP)deploy$(PATHSEP)kuzzlesdk-$(VERSION)-$(ARCH).tar.gz lib include
 
 build_test: $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION)
 	cd $(ROOT_DIR)$(PATHSEP)test && sh build_cpp_tests.sh


### PR DESCRIPTION
## What does this PR do ?
Update CI to get:
*  `master` artifacts stored as `kuzzlesdk-cpp-$ARCH-$VERSION.tar.gz`
*  `*-dev` artifacts stored as `kuzzlesdk-cpp-$ARCH.tar.gz`

### How should this be manually tested?
You cannot sorry :/
