### PR TITLE
Fix realtime count arguments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,25 @@
 
 Here are a few rules and guidelines to follow if you want to contribute to the Java SDK and, more importantly, if you want to see your pull requests accepted by the  Kuzzle team.
 
-## Tools
-
-This SDK inherits from the following repositories, linked as git submodules: sdk-c, sdk-go.  
-Whenever significant changes are applied to the parent SDKs, you need to align the linked submodules accordingly.
-You can use `align-submodules.sh` script to achieve this. (e.g.: `./align-submodules.sh 1-dev` to align all submodules on `1-dev` branch)
-
+## Build the SDK
 
 You can use this Docker image to build the SDK:  
 ```
 docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make all
 ```
+
+## Compile with the SDK
+
+Use this commande to compile a cpp source file with the builded SDK:
+`g++ -std=c++11 source.cpp -Isdk-c/include -Isdk-c/build/ -Iinclude -L./build/ -lkuzzlesdk -lpthread`
+
+Then run the compiled program with: `LD_LIBRARY_PATH=./build ./a.out`
+
+## Tools
+
+This SDK inherits from the following repositories, linked as git submodules: sdk-c, sdk-go.  
+Whenever significant changes are applied to the parent SDKs, you need to align the linked submodules accordingly.
+You can use `align-submodules.sh` script to achieve this. (e.g.: `./align-submodules.sh 1-dev` to align all submodules on `1-dev` branch)
 
 ## Running Tests
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ make_c_sdk:
 	cd sdk-c && $(MAKE)
 
 cpp: export GOPATH = $(ROOT_DIR)go
-cpp: makedir update_submodule make_c_sdk $(CPPSDK)
+cpp: makedir make_c_sdk $(CPPSDK)
 		$(AR) rvs $(ROOTOUTDIR)$(PATHSEP)libkuzzlesdk$(STATICLIB) src$(PATHSEP)*.o
 		$(CXX) -shared -fPIC -o $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB) -Wl,--whole-archive $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB) sdk-c$(PATHSEP)build$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB) -Wl,--no-whole-archive
 		cd $(ROOTOUTDIR) && mv $(LIB_PREFIX)kuzzlesdk$(STATICLIB) $(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION) && mv $(LIB_PREFIX)kuzzlesdk$(DYNLIB) $(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION)

--- a/include/realtime.hpp
+++ b/include/realtime.hpp
@@ -21,7 +21,7 @@ namespace kuzzleio {
       Realtime(Kuzzle* kuzzle);
       Realtime(Kuzzle* kuzzle, realtime* realtime);
       virtual ~Realtime();
-      int count(const std::string& index, const std::string& collection, const std::string& roomId, query_options *options=nullptr);
+      int count(const std::string& roomId, query_options *options=nullptr);
       std::string list(const std::string& index, const std::string& collection, query_options *options=nullptr);
       void publish(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
       std::string subscribe(const std::string& index, const std::string& collection, const std::string& body, NotificationListener* cb, room_options* options=nullptr);

--- a/src/realtime.cpp
+++ b/src/realtime.cpp
@@ -17,8 +17,8 @@ namespace kuzzleio {
     delete(_realtime);
   }
 
-  int Realtime::count(const std::string& index, const std::string& collection, const std::string& roomId, query_options *options) {
-    int_result *r = kuzzle_realtime_count(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(roomId.c_str()), options);
+  int Realtime::count(const std::string& roomId, query_options *options) {
+    int_result *r = kuzzle_realtime_count(_realtime, const_cast<char*>(roomId.c_str()), options);
     if (r->error != nullptr)
         throwExceptionFromStatus(r);
     int ret = r->result;


### PR DESCRIPTION
## What does this PR do ?

This PR remove the unused `index` and `collection` parameters for Realtime.Count

:arrow_left: https://github.com/kuzzleio/sdk-c/pull/21 :large_blue_circle: 

## Other changes

 - add compile and run instructions