### PR TITLE
Remove realtime deprecated methods

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,10 @@
   List any dependencies that are required for this change.
 -->
 
+<!-- Uncomment this section to link PR on other SDKs
+https://github.com/kuzzleio/sdk-c/pull/ :arrow_left: :large_blue_circle:
+-->
+
 ### How should this be manually tested?
 
 <!--

--- a/include/realtime.hpp
+++ b/include/realtime.hpp
@@ -22,11 +22,9 @@ namespace kuzzleio {
       Realtime(Kuzzle* kuzzle, realtime* realtime);
       virtual ~Realtime();
       int count(const std::string& index, const std::string& collection, const std::string& roomId, query_options *options=nullptr);
-      std::string list(const std::string& index, const std::string& collection, query_options *options=nullptr);
       void publish(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
       std::string subscribe(const std::string& index, const std::string& collection, const std::string& body, NotificationListener* cb, room_options* options=nullptr);
       void unsubscribe(const std::string& roomId, query_options *options=nullptr);
-      bool validate(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
 
       NotificationListener* getListener(const std::string& roomId);
   };

--- a/src/realtime.cpp
+++ b/src/realtime.cpp
@@ -40,15 +40,6 @@ namespace kuzzleio {
     }
   }
 
-  std::string Realtime::list(const std::string& index, const std::string& collection, query_options *options) {
-    string_result *r = kuzzle_realtime_list(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
-    std::string ret = r->result;
-    kuzzle_free_string_result(r);
-    return ret;
-  }
-
   void Realtime::publish(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
     error_result *r = kuzzle_realtime_publish(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
     if (r != nullptr)
@@ -76,14 +67,5 @@ namespace kuzzleio {
 
     _listener_instances[roomId] = nullptr;
     kuzzle_free_error_result(r);
-  }
-
-  bool Realtime::validate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    bool_result *r = kuzzle_realtime_validate(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()),  const_cast<char*>(body.c_str()), options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
-    bool ret = r->result;
-    kuzzle_free_bool_result(r);
-    return ret;
   }
 }


### PR DESCRIPTION
## What does this PR do ?

The following are deprecated and will be removed in Kuzzle v2:
 - `realtime:join` : useless method
 - `realtime:list` : useless method
 - `realtime:validate` : duplicate with `document:validate`

 https://github.com/kuzzleio/sdk-c/pull/23 :arrow_left: :large_blue_circle:

### How should this be manually tested?

  - Step 1 : Make the sdk
  - Step 2 :
  - Step 3 :  

### Other change

  - Add optional template to link other sdk PRs