### PR TITLE
[fix] Add sdk-c/build/kuzzle.h to archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ CPP_SDK_SRCS = src$(PATHSEP)kuzzle.cpp \
 					src$(PATHSEP)realtime.cpp \
 					src$(PATHSEP)search_result.cpp \
 					src$(PATHSEP)server.cpp \
-					src$(PATHSEP)specification_search_result.cpp 
+					src$(PATHSEP)specification_search_result.cpp
 
 CPPSDK = $(CPP_SDK_SRCS:%.cpp=%.o)
 
@@ -79,8 +79,10 @@ package: $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(ROO
 	cp -fr $(ROOT_DIR)$(PATHSEP)include$(PATHSEP)*.hpp $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP)kuzzlesdk.h $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP)sdk_wrappers_internal.h $(ROOTOUTDIR)$(PATHSEP)include
+	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP)kuzzle.h $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOTOUTDIR)$(PATHSEP)*.so  $(ROOTOUTDIR)$(PATHSEP)lib
 	cp $(ROOTOUTDIR)$(PATHSEP)*.a  $(ROOTOUTDIR)$(PATHSEP)lib
+
 	mkdir deploy && cd $(ROOTOUTDIR) && tar cfz ..$(PATHSEP)deploy$(PATHSEP)kuzzlesdk-cpp-$(VERSION)-$(ARCH).tar.gz lib include
 
 build_test: $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION)


### PR DESCRIPTION
## What does this PR do ?
Add missing `sdk-c/build/kuzzle.h` to package archive 

### How should this be manually tested?
Run : 
* `docker run --rm -it --privileged --network ci_default -e ARCH='amd64' -v "$(pwd)":/mnt kuzzleio/sdk-cross:openjdk8 make clean all`
* `docker run --rm -it --privileged --network ci_default -e ARCH='amd64' -v "$(pwd)":/mnt kuzzleio/sdk-cross:openjdk8 make package`
* Go to `deploy` folder and extract `*tar.gz` content.
* Check that `kuzzle.h` is present in `deploy/include` folder. 