### PR TITLE
Kzl 832 document count body optional

### DIFF
--- a/include/document.hpp
+++ b/include/document.hpp
@@ -29,7 +29,7 @@ namespace kuzzleio {
             Document(Kuzzle* kuzzle);
             Document(Kuzzle* kuzzle, document *document);
             virtual ~Document();
-            int count(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
+            int count(const std::string& index, const std::string& collection, const std::string& body="", query_options *options=nullptr);
             bool exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options=nullptr);
             std::string create(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);
             std::string createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);

--- a/include/document.hpp
+++ b/include/document.hpp
@@ -29,7 +29,8 @@ namespace kuzzleio {
             Document(Kuzzle* kuzzle);
             Document(Kuzzle* kuzzle, document *document);
             virtual ~Document();
-            int count(const std::string& index, const std::string& collection, const std::string& body="", query_options *options=nullptr);
+            int count(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
+            int count(const std::string& index, const std::string& collection, query_options *options=nullptr);
             bool exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options=nullptr);
             std::string create(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);
             std::string createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -33,12 +33,18 @@ namespace kuzzleio {
     }
 
     int Document::count(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-      int_result *r = kuzzle_document_count(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-      if (r->error != nullptr)
-          throwExceptionFromStatus(r);
-      int ret = r->result;
-      kuzzle_free_int_result(r);
-      return ret;
+        char* rbody;
+        
+        if (!body.empty()) {
+            rbody = const_cast<char*>(body.c_str());
+        }
+
+        int_result *r = kuzzle_document_count(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), rbody, options);
+        if (r->error != nullptr)
+            throwExceptionFromStatus(r);
+        int ret = r->result;
+        kuzzle_free_int_result(r);
+        return ret;
     }
 
     bool Document::exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -34,7 +34,7 @@ namespace kuzzleio {
 
     int Document::count(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
         char* rbody;
-        
+
         if (!body.empty()) {
             rbody = const_cast<char*>(body.c_str());
         }
@@ -45,6 +45,10 @@ namespace kuzzleio {
         int ret = r->result;
         kuzzle_free_int_result(r);
         return ret;
+    }
+
+    int Document::count(const std::string& index, const std::string& collection, query_options *options) {
+        return count(index, collection, "", options);
     }
 
     bool Document::exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {


### PR DESCRIPTION
**:warning: do not merge**
**:warning: depends on https://github.com/kuzzleio/kuzzle/pull/1214**

## What does this PR do?

Following https://github.com/kuzzleio/kuzzle/pull/1214, makes `document.count` `body` property optional.

https://github.com/kuzzleio/sdk-c/pull/30 :arrow_left: :large_blue_circle: 