### PR TITLE
Fix missing include in package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test/_build_cpp_tests/
+deploy/
 *.o
 build/

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ package: $(ROOTOUTDIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(ROO
 	cp -fr $(ROOT_DIR)$(PATHSEP)include$(PATHSEP)*.hpp $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP)kuzzlesdk.h $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP)sdk_wrappers_internal.h $(ROOTOUTDIR)$(PATHSEP)include
+	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)include$(PATHSEP)protocol.h $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOT_DIR)$(PATHSEP)sdk-c$(PATHSEP)build$(PATHSEP)kuzzle.h $(ROOTOUTDIR)$(PATHSEP)include
 	cp $(ROOTOUTDIR)$(PATHSEP)*.so  $(ROOTOUTDIR)$(PATHSEP)lib
 	cp $(ROOTOUTDIR)$(PATHSEP)*.a  $(ROOTOUTDIR)$(PATHSEP)lib


### PR DESCRIPTION
# Description

The .tar.gz misses the `protocol.h` header from the C SDK. This makes anyone using our C++ SDK package get compilation errors.

To check if the problem is fixed: `make && make package` => check the .tar.gz file in the `deploy/` folder

# How to reproduce

Download the C++ SDK from the S3 server ([direct link](https://dl.kuzzle.io/sdk/cpp/1-dev/index.html) ), and inspect any archive: the file `protocol.h` is missing, but required by at least the `protocol.hpp` header file.

# Other change

Add the `deploy` folder to the .gitignore file