### PR TITLE
Fix missing C header file in the C++ includes

### DIFF
--- a/include/core.hpp
+++ b/include/core.hpp
@@ -21,6 +21,7 @@
 extern "C" {
   #include "kuzzle.h"
   #include "kuzzlesdk.h"
+  #include "protocol.h"
 }
 
 #endif


### PR DESCRIPTION
# Description

The `protocol.h` C header file is needed in multiple places in this SDK, yet it isn't included anywhere.

This PR fixes that.