### PR TITLE
Remove getters in protocol interface

### DIFF
--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -32,6 +32,7 @@ namespace kuzzleio {
     virtual void stopQueuing() = 0;
     virtual void playQueue() = 0;
     virtual void clearQueue() = 0;
+    virtual std::string getHost() = 0;
   };
 
 }

--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -32,14 +32,6 @@ namespace kuzzleio {
     virtual void stopQueuing() = 0;
     virtual void playQueue() = 0;
     virtual void clearQueue() = 0;
-
-    // Getters
-    virtual bool isAutoReconnect() = 0;
-    virtual bool isAutoResubscribe() = 0;
-    virtual std::string getHost() = 0;
-    virtual unsigned int getPort() = 0;
-    virtual unsigned long long getReconnectionDelay() = 0;
-    virtual bool isSslConnection() = 0;
   };
 
 }

--- a/include/websocket.hpp
+++ b/include/websocket.hpp
@@ -39,12 +39,12 @@ namespace kuzzleio {
     virtual void clearQueue();
 
     // Getters
-    virtual bool isAutoReconnect();
-    virtual bool isAutoResubscribe();
-    virtual std::string getHost();
-    virtual unsigned int getPort();
-    virtual unsigned long long getReconnectionDelay();
-    virtual bool isSslConnection();
+    bool isAutoReconnect();
+    bool isAutoResubscribe();
+    std::string getHost();
+    unsigned int getPort();
+    unsigned long long getReconnectionDelay();
+    bool isSslConnection();
   };
 
 }

--- a/include/websocket.hpp
+++ b/include/websocket.hpp
@@ -37,11 +37,11 @@ namespace kuzzleio {
     virtual void stopQueuing();
     virtual void playQueue();
     virtual void clearQueue();
+    virtual std::string getHost();
 
     // Getters
     bool isAutoReconnect();
     bool isAutoResubscribe();
-    std::string getHost();
     unsigned int getPort();
     unsigned long long getReconnectionDelay();
     bool isSslConnection();

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -116,30 +116,6 @@ namespace kuzzleio {
     static_cast<Protocol*>(data)->removeAllListeners(static_cast<Event>(event));
   }
 
-  bool bridge_cpp_is_auto_reconnect(void* data) {
-    return static_cast<Protocol*>(data)->isAutoReconnect();
-  }
-
-  bool bridge_cpp_is_auto_resubscribe(void* data) {
-    return static_cast<Protocol*>(data)->isAutoResubscribe();
-  }
-
-  const char* bridge_cpp_get_host(void* data) {
-    return static_cast<Protocol*>(data)->getHost().c_str();
-  }
-
-  unsigned int bridge_cpp_get_port(void* data) {
-    return static_cast<Protocol*>(data)->getPort();
-  }
-
-  unsigned long long bridge_cpp_get_reconnection_delay(void* data) {
-    return static_cast<Protocol*>(data)->getReconnectionDelay();
-  }
-
-  bool bridge_cpp_is_ssl_connection(void* data) {
-    return static_cast<Protocol*>(data)->isSslConnection();
-  }
-
   // Class
   KuzzleException::KuzzleException(int status, const std::string& error)
     : std::runtime_error(error), status(status) {}
@@ -171,13 +147,7 @@ namespace kuzzleio {
     proto->_protocol->play_queue = bridge_cpp_play_queue;
     proto->_protocol->clear_queue = bridge_cpp_clear_queue;
     proto->_protocol->remove_all_listeners = bridge_cpp_remove_all_listeners;
-    proto->_protocol->is_auto_reconnect = bridge_cpp_is_auto_reconnect;
-    proto->_protocol->is_auto_resubscribe = bridge_cpp_is_auto_resubscribe;
-    proto->_protocol->get_host = bridge_cpp_get_host;
-    proto->_protocol->get_port = bridge_cpp_get_port;
-    proto->_protocol->get_reconnection_delay = bridge_cpp_get_reconnection_delay;
-    proto->_protocol->is_ssl_connection = bridge_cpp_is_ssl_connection;
-
+    
     this->_protocol = proto->_protocol;
     this->_cpp_protocol = proto;
 

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -116,6 +116,10 @@ namespace kuzzleio {
     static_cast<Protocol*>(data)->removeAllListeners(static_cast<Event>(event));
   }
 
+  const char* bridge_cpp_get_host(void* data) {
+    return static_cast<Protocol*>(data)->getHost().c_str();
+  }
+
   // Class
   KuzzleException::KuzzleException(int status, const std::string& error)
     : std::runtime_error(error), status(status) {}
@@ -147,7 +151,8 @@ namespace kuzzleio {
     proto->_protocol->play_queue = bridge_cpp_play_queue;
     proto->_protocol->clear_queue = bridge_cpp_clear_queue;
     proto->_protocol->remove_all_listeners = bridge_cpp_remove_all_listeners;
-    
+    proto->_protocol->get_host = bridge_cpp_get_host;
+
     this->_protocol = proto->_protocol;
     this->_cpp_protocol = proto;
 


### PR DESCRIPTION
## What does this PR do ?

As I was writting the documentation of the protocol interface I just thought it was useless to put getters in this interface (except for the getHost because it is used in the Kuzzle object) as developers can still implements getters in their class which inherit this Protocol interface (see websocket.cpp for instance).

### How should this be manually tested?

See travis.
