### PR TITLE
Add valgrind to functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ jobs:
         - docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-armhf make all build_test
         # Test
         - docker run --rm --privileged multiarch/qemu-user-static:register
-        - docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:armhf-cpp-runner make run_test
+        - docker run --rm -it -e SKIPVALGRIND=1 --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:armhf-cpp-runner make run_test
 
       after_success:
         - docker run --rm -it -e ARCH=armhf -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-armhf make package
@@ -179,7 +179,7 @@ jobs:
         - docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-aarch64 make all build_test
         # Test
         - docker run --rm --privileged multiarch/qemu-user-static:register
-        - docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:aarch64-cpp-runner make run_test
+        - docker run --rm -it -e SKIPVALGRIND=1 --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:aarch64-cpp-runner make run_test
 
       after_success:
         - docker run --rm -it -e ARCH=aarch64 -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc-aarch64 make package

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ package: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUIL
 build_test: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION)
 	cd test && sh build_cpp_tests.sh
 
-run_test: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION)
+run_test:
 	SKIPBUILD=1 sh run-tests.sh
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSION = 1.0.0
+SHELL = /bin/bash
 
 ROOT_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,8 @@ package: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUIL
 build_test: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION)
 	cd test && sh build_cpp_tests.sh
 
-run_test:
-	cd test && .$(PATHSEP)_build_cpp_tests$(PATHSEP)KuzzleSDKStepDefs > /dev/null &
-	cd test && cucumber
+run_test: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION)
+	SKIPBUILD=1 sh run-tests.sh
 
 clean:
 	cd sdk-c && make clean
@@ -100,7 +99,7 @@ ifeq ($(OS),Windows_NT)
 else
 	$(RRM) $(BUILD_DIR) deploy test$(PATHSEP)_build_cpp_tests
 endif
-.PHONY: all core clean run_test 
+.PHONY: all core clean run_test
 
 
 .DEFAULT_GOAL := all

--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,10 @@ package: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUIL
 	mkdir -p deploy && cd $(BUILD_DIR) && tar cfz ..$(PATHSEP)deploy$(PATHSEP)kuzzlesdk-cpp-$(VERSION)-$(ARCH).tar.gz $(SDK_FOLDER_NAME)
 
 build_test: $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(DYNLIB).$(VERSION) $(BUILD_DIR)$(PATHSEP)$(LIB_PREFIX)kuzzlesdk$(STATICLIB).$(VERSION)
-	cd test && sh build_cpp_tests.sh
+	cd test && ./build_cpp_tests.sh
 
 run_test:
-	SKIPBUILD=1 sh run-tests.sh
+	SKIPBUILD=1 ./run-tests.sh
 
 clean:
 	cd sdk-c && make clean

--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ To manually run the bundled tests on this SDK, you need the following dependenci
 - ruby
 - the `bundler` gem (`gem install bundler`)
 - tests' dependencies: `bundle install --gemfile test/Gemfile`
+- valgrind: `sudo apt install -y valgrind`
 
 Once done, you can start the functional tests with the following command:
 
 ```
 ./run-tests.sh
 ```
+
+The test results are printed to the standard output.
+
+Functional tests are monitored by valgrind. The report is available here: `./test/_build_cpp_tests/valgrind_report.log`

--- a/README.md
+++ b/README.md
@@ -45,10 +45,7 @@ x86:  https://dl.kuzzle.io/sdk/c/master/kuzzlesdk-cpp-x86-1.0.0.tar.gz
 To manually run the bundled tests on this SDK, you need the following dependencies installed:
 
 - boost libraries (https://www.boost.org/)
-- ruby
-- the `bundler` gem (`gem install bundler`)
-- tests' dependencies: `bundle install --gemfile test/Gemfile`
-- valgrind: `sudo apt install -y valgrind`
+- cucumber, cmake & valgrind: `sudo apt install -y cmake cucumber valgrind`
 
 Once done, you can start the functional tests with the following command:
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,18 +1,57 @@
 #!/usr/bin/env bash
 
 set -e
-
 cd test
+
+export CUCUMBER_HOST='localhost'
+export CUCUMBER_PORT='3902'
+
+VALGRIND_LOGFILE='./_build_cpp_tests/valgrind_report.log'
+CUCUMBER_LOGFILE='./_build_cpp_tests/cucumber.log'
+
+# initializes the valgrind suppression arguments
+for supp in ./valgrind.*.supp; do
+  VALGRIND_SUPPR="${VALGRIND_ARG_SUPP} --suppressions=${supp}"
+done
 
 FEATURE_FILE=$1
 
 ./build_cpp_tests.sh
-./_build_cpp_tests/KuzzleSDKStepDefs &
+
+valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIND_SUPPR} --log-file=${VALGRIND_LOGFILE} ./_build_cpp_tests/KuzzleSDKStepDefs &
+
+# Should generally be enough to let valgrind initialize
+# and start the server.
+# If not, there is a retry mechanism fallback below
+sleep 2
 
 if [ ! -z "$FEATURE_FILE" ]; then
-  bundle exec cucumber ./features/sdk-features/$FEATURE_FILE
+  CMD="bundle exec cucumber ./features/sdk-features/$FEATURE_FILE"
 else
-  bundle exec cucumber
+  CMD="bundle exec cucumber"
 fi
+
+${CMD} 2>&1 | tee ${CUCUMBER_LOGFILE}
+
+# Restart Cucumber if the wire server wasn't ready
+# We cannot check the connection port beforehand (e.g. with netcat),
+# because the wire protocol makes the step definitions exit whenever
+# a disconnection is detected
+let retries=5
+
+while [ "$(grep 'Unable to contact the wire server' ${CUCUMBER_LOGFILE})" ]; do
+  if [ ${retries} -eq 0 ]; then
+    echo "No more retries available. Aborting."
+    exit 2
+  fi
+
+  let retries--
+
+  echo "Cucumber Wire connection problem detected."
+  echo "Retrying in 5 seconds (${retries} retries left)."
+  sleep 5
+
+  ${CMD} 2>&1 | tee ${CUCUMBER_LOGFILE}
+done
 
 cd -

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ CUCUMBER_LOGFILE='./_build_cpp_tests/cucumber.log'
 
 # initializes the valgrind suppression arguments
 for supp in ./valgrind.*.supp; do
-  VALGRIND_SUPPR="${VALGRIND_ARG_SUPP} --suppressions=${supp}"
+  VALGRIND_SUPPR="${VALGRIND_SUPPR} --suppressions=${supp}"
 done
 
 FEATURE_FILE=$1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -27,10 +27,10 @@ valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIN
 # If not, there is a retry mechanism fallback below
 sleep 2
 
+CMD="cucumber"
+
 if [ ! -z "$FEATURE_FILE" ]; then
-  CMD="bundle exec cucumber ./features/sdk-features/$FEATURE_FILE"
-else
-  CMD="bundle exec cucumber"
+  CMD="${CMD} ./features/sdk-features/$FEATURE_FILE"
 fi
 
 ${CMD} 2>&1 | tee ${CUCUMBER_LOGFILE}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,7 +16,9 @@ done
 
 FEATURE_FILE=$1
 
-./build_cpp_tests.sh
+if [ -z "${SKIPBUILD}" -o "${SKIPBUILD}" = 0 ]; then
+  ./build_cpp_tests.sh
+fi
 
 valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIND_SUPPR} --log-file=${VALGRIND_LOGFILE} ./_build_cpp_tests/KuzzleSDKStepDefs &
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,4 +14,5 @@ if [ ! -z "$FEATURE_FILE" ]; then
 else
   bundle exec cucumber
 fi
- cd -
+
+cd -

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,7 +20,7 @@ if [ -z "${SKIPBUILD}" -o "${SKIPBUILD}" = 0 ]; then
   ./build_cpp_tests.sh
 fi
 
-valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIND_SUPPR} --log-file=${VALGRIND_LOGFILE} ./_build_cpp_tests/KuzzleSDKStepDefs &
+ #valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIND_SUPPR} --log-file=${VALGRIND_LOGFILE} ./_build_cpp_tests/KuzzleSDKStepDefs &
 
 # Should generally be enough to let valgrind initialize
 # and start the server.
@@ -39,7 +39,7 @@ ${CMD} 2>&1 | tee ${CUCUMBER_LOGFILE}
 # We cannot check the connection port beforehand (e.g. with netcat),
 # because the wire protocol makes the step definitions exit whenever
 # a disconnection is detected
-let retries=5
+retries=5
 
 while [ "$(grep 'Unable to contact the wire server' ${CUCUMBER_LOGFILE})" ]; do
   if [ ${retries} -eq 0 ]; then
@@ -47,7 +47,7 @@ while [ "$(grep 'Unable to contact the wire server' ${CUCUMBER_LOGFILE})" ]; do
     exit 2
   fi
 
-  let retries--
+  retries=$((retries-1))
 
   echo "Cucumber Wire connection problem detected."
   echo "Retrying in 5 seconds (${retries} retries left)."

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,7 +20,13 @@ if [ -z "${SKIPBUILD}" -o "${SKIPBUILD}" = 0 ]; then
   ./build_cpp_tests.sh
 fi
 
-valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIND_SUPPR} --log-file=${VALGRIND_LOGFILE} ./_build_cpp_tests/KuzzleSDKStepDefs &
+VALGRIND=""
+
+if [ -z "${SKIPVALGRIND}" -o "${SKIPVALGRIND}" = 0 ]; then
+  VALGRIND="valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIND_SUPPR} --log-file=${VALGRIND_LOGFILE}"
+fi
+
+${VALGRIND} ./_build_cpp_tests/KuzzleSDKStepDefs &
 
 # Should generally be enough to let valgrind initialize
 # and start the server.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 cd test
 
 export CUCUMBER_HOST='localhost'
@@ -18,8 +17,6 @@ FEATURE_FILE=$1
 if [ -z "${SKIPBUILD}" -o "${SKIPBUILD}" = 0 ]; then
   ./build_cpp_tests.sh
 fi
-
-VALGRIND=""
 
 if [ -z "${SKIPVALGRIND}" -o "${SKIPVALGRIND}" = 0 ]; then
   valgrind --leak-check=full --show-reachable=yes --gen-suppressions=all ${VALGRIND_SUPPR} --log-file=${VALGRIND_LOGFILE} ./_build_cpp_tests/KuzzleSDKStepDefs &

--- a/test/features/step_definitions/CMakeLists.txt
+++ b/test/features/step_definitions/CMakeLists.txt
@@ -4,6 +4,11 @@ project(KuzzleSKDTests)
 include(ExternalProject)
 
 #
+# Force debug flags for valgrind
+#
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g -O0")
+
+#
 # Cucumber CPP
 #
 
@@ -13,8 +18,8 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
 
     CMAKE_CACHE_ARGS
-      -DCUKE_DISABLE_QT:BOOL=ON 
-      -DCUKE_ENABLE_EXAMPLES:BOOL=OFF 
+      -DCUKE_DISABLE_QT:BOOL=ON
+      -DCUKE_ENABLE_EXAMPLES:BOOL=OFF
       -DCUKE_DISABLE_GTEST:BOOL=ON
       -DCUKE_DISABLE_UNIT_TESTS:BOOL=ON
       -DCUKE_DISABLE_E2E_TESTS:BOOL=ON
@@ -41,7 +46,7 @@ add_library(cucumber-cpp STATIC IMPORTED) # or STATIC instead of SHARED
 add_dependencies(cucumber-cpp project_cucumber_cpp)
 set_target_properties(cucumber-cpp PROPERTIES
     IMPORTED_LOCATION ${CUCUMBER_CPP_LIBRARY_PATH}
-    INTERFACE_INCLUDE_DIRECTORIES  
+    INTERFACE_INCLUDE_DIRECTORIES
         "${CUCUMBER_CPP_INCLUDE_PATH}"
     DEPENDS project_cucumber_cpp
 )
@@ -53,7 +58,7 @@ set_target_properties(cucumber-cpp PROPERTIES
 add_subdirectory(3rdparty/json_spirit)
 
 #
-# Kuzzle SDK 
+# Kuzzle SDK
 #
 
 get_filename_component(KUZZLE_SDK_ROOT "${CMAKE_SOURCE_DIR}/../../../src" ABSOLUTE)
@@ -101,7 +106,7 @@ if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
 
     add_library(kuzzlesdk SHARED IMPORTED) # or STATIC instead of SHARED
     set_target_properties(kuzzlesdk PROPERTIES
-    IMPORTED_LOCATION "${KUZZLE_SDK_ROOT}/../sdk-c/build/libkuzzlesdk.a" 
+    IMPORTED_LOCATION "${KUZZLE_SDK_ROOT}/../sdk-c/build/libkuzzlesdk.so"
     INTERFACE_INCLUDE_DIRECTORIES "${KUZZLE_SDK_ROOT}/../include/"
     )
 

--- a/test/features/step_definitions/cucumber.wire
+++ b/test/features/step_definitions/cucumber.wire
@@ -1,5 +1,5 @@
-host: localhost
-port: 3902
+host: <%= ENV['CUCUMBER_HOST'] || 'localhost' %>
+port: <%= ENV['CUCUMBER_PORT'] || 3902 %>
 timeout:
   invoke: 30
   step_matches: 60

--- a/test/features/step_definitions/kuzzle-sdk-steps.cpp
+++ b/test/features/step_definitions/kuzzle-sdk-steps.cpp
@@ -5,15 +5,6 @@
 namespace {
   BEFORE() { kuz_log_sep(); }
 
-  AFTER() {
-    ScenarioScope<KuzzleCtx> ctx;
-
-    if (ctx->kuzzle != NULL) {
-      delete ctx->kuzzle;
-      delete ctx->protocol;
-    }
-  }
-
   GIVEN("^I update my user custom data with the pair '(.+)':'(.+)'$")
   {
     REGEX_PARAM(std::string, fieldname);

--- a/test/features/step_definitions/kuzzle-sdk-steps.cpp
+++ b/test/features/step_definitions/kuzzle-sdk-steps.cpp
@@ -5,6 +5,15 @@
 namespace {
   BEFORE() { kuz_log_sep(); }
 
+  AFTER() {
+    ScenarioScope<KuzzleCtx> ctx;
+
+    if (ctx->kuzzle != NULL) {
+      delete ctx->kuzzle;
+      delete ctx->protocol;
+    }
+  }
+
   GIVEN("^I update my user custom data with the pair '(.+)':'(.+)'$")
   {
     REGEX_PARAM(std::string, fieldname);

--- a/test/features/step_definitions/realtime-steps.cpp
+++ b/test/features/step_definitions/realtime-steps.cpp
@@ -40,11 +40,11 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     sleep(1);
-    BOOST_CHECK(ctx->notif_result != NULL);
+    BOOST_CHECK(ctx->notif_result != nullptr);
     ctx->kuzzle->realtime->unsubscribe(ctx->room_id);
 
     delete ctx->notif_result;
-    ctx->notif_result = NULL;
+    ctx->notif_result = nullptr;
   }
 
   GIVEN("^I subscribe to \'([^\"]*)\' with \'(.*)\' as filter$") {

--- a/test/valgrind.cgosdk.supp
+++ b/test/valgrind.cgosdk.supp
@@ -1,7 +1,6 @@
 {
    Cgo wrapper
-   Memcheck:Leak
-   fun:*alloc
+   Memcheck:Addr8
    ...
    obj:*/libkuzzlesdk.so*
 }
@@ -26,9 +25,34 @@
    fun:*kuzzle_connect
 }
 {
+   main.bridge_notification
+   Memcheck:Addr1
+   fun:main.bridge_notification
+}
+{
+   main.cToGo*
+   Memcheck:Addr8
+   fun:main.cToGo*
+}
+{
    main.func_bridge_connect
    Memcheck:Addr8
    fun:main._Cfunc_bridge_connect
+}
+{
+   func_CString
+   Memcheck:Addr8
+   fun:main._Cfunc_CString
+}
+{
+   main.goToC*
+   Memcheck:Addr1
+   fun:main.goToC*
+}
+{
+   main.goToC*
+   Memcheck:Addr8
+   fun:main.goToC*
 }
 {
    main.kuzzle_connect
@@ -36,17 +60,26 @@
    fun:main.*kuzzle_connect*
 }
 {
-   main.*kuzzle_websocket_connect
+   main.kuzzle_set_default_query_options
+   Memcheck:Addr1
+   fun:main.kuzzle_set_default_query_options
+}
+{
+   main.kuzzle_set_default_query_options
+   Memcheck:Addr8
+   fun:main.kuzzle_set_default_query_options
+}
+{
+   main.*kuzzle_websocket_*
    Memcheck:Addr8
    ...
-   fun:main.*kuzzle_websocket_connect*
+   fun:main.*kuzzle_websocket_*
 }
 {
    main.WrapProtocol
    Memcheck:Addr1
    fun:main.WrapProtocol.*
 }
-
 {
    main.WrapProtocol
    Memcheck:Addr8

--- a/test/valgrind.cgosdk.supp
+++ b/test/valgrind.cgosdk.supp
@@ -1,0 +1,54 @@
+{
+   Cgo wrapper
+   Memcheck:Leak
+   fun:*alloc
+   ...
+   obj:*/libkuzzlesdk.so*
+}
+{
+   Cgo wrapper
+   Memcheck:Cond
+   obj:*/libkuzzlesdk.so*
+}
+{
+   Cgo wrapper
+   Memcheck:Value8
+   obj:*/libkuzzlesdk.so*
+}
+{
+   kuzzle_connect through bridge
+   Memcheck:Addr8
+   fun:_*func_bridge_connect
+   fun:runtime.asmcgocall
+   ...
+   fun:runtime.cgocallback_gofunc
+   fun:runtime.cgocallback
+   fun:*kuzzle_connect
+}
+{
+   main.func_bridge_connect
+   Memcheck:Addr8
+   fun:main._Cfunc_bridge_connect
+}
+{
+   main.kuzzle_connect
+   Memcheck:Addr8
+   fun:main.*kuzzle_connect*
+}
+{
+   main.*kuzzle_websocket_connect
+   Memcheck:Addr8
+   ...
+   fun:main.*kuzzle_websocket_connect*
+}
+{
+   main.WrapProtocol
+   Memcheck:Addr1
+   fun:main.WrapProtocol.*
+}
+
+{
+   main.WrapProtocol
+   Memcheck:Addr8
+   fun:main.WrapProtocol.*
+}

--- a/test/valgrind.godeps.supp
+++ b/test/valgrind.godeps.supp
@@ -1,0 +1,54 @@
+{
+   Kuzzle Go SDK
+   Memcheck:Addr1
+   ...
+   fun:github.com/kuzzleio/sdk-go/*
+}
+{
+   Kuzzle Go SDK
+   Memcheck:Addr4
+   ...
+   fun:github.com/kuzzleio/sdk-go/*
+}
+{
+   Kuzzle Go SDK
+   Memcheck:Addr8
+   ...
+   fun:github.com/kuzzleio/sdk-go/*
+}
+{
+   Kuzzle Go SDK
+   Memcheck:Addr16
+   ...
+   fun:github.com/kuzzleio/sdk-go/*
+}
+{
+   Gorilla WebSocket
+   Memcheck:Addr8
+   ...
+   fun:github.com/gorilla/websocket.*
+}
+{
+   Gorilla WebSocket
+   Memcheck:Addr1
+   ...
+   fun:github.com/gorilla/websocket.*
+}
+{
+   Gorilla WebSocket
+   Memcheck:Addr4
+   ...
+   fun:github.com/gorilla/websocket.*
+}
+{
+   uuid
+   Memcheck:Addr8
+   ...
+   fun:github.com/satori/go%2euuid.*
+}
+{
+   uuid
+   Memcheck:Addr16
+   ...
+   fun:github.com/satori/go%2euuid.*
+}

--- a/test/valgrind.godeps.supp
+++ b/test/valgrind.godeps.supp
@@ -50,11 +50,11 @@
    uuid
    Memcheck:Addr8
    ...
-   fun:github.com/satori/go%2euuid.*
+   fun:github.com/satori/*uuid.*
 }
 {
    uuid
    Memcheck:Addr16
    ...
-   fun:github.com/satori/go%2euuid.*
+   fun:github.com/satori/*uuid.*
 }

--- a/test/valgrind.godeps.supp
+++ b/test/valgrind.godeps.supp
@@ -36,6 +36,12 @@
 }
 {
    Gorilla WebSocket
+   Memcheck:Addr2
+   ...
+   fun:github.com/gorilla/websocket.*
+}
+{
+   Gorilla WebSocket
    Memcheck:Addr4
    ...
    fun:github.com/gorilla/websocket.*

--- a/test/valgrind.goruntime.supp
+++ b/test/valgrind.goruntime.supp
@@ -1,0 +1,115 @@
+{
+   bufio.fill
+   Memcheck:Addr8
+   fun:bufio.*
+}
+{
+   crypto
+   Memcheck:Addr8
+   fun:crypto/*
+}
+{
+   crypto
+   Memcheck:Addr1
+   fun:crypto/*
+}
+{
+   encoding
+   Memcheck:Addr1
+   fun:encoding/*
+}
+{
+   encoding
+   Memcheck:Addr8
+   fun:encoding/*
+}
+{
+   fmt
+   Memcheck:Addr8
+   fun:fmt.*
+}
+{
+   internal
+   Memcheck:Addr1
+   fun:internal/poll.*
+}
+{
+   internal
+   Memcheck:Addr8
+   fun:internal/poll.*
+}
+{
+   io
+   Memcheck:Addr8
+   fun:io.*
+}
+{
+   net.*
+   Memcheck:Addr8
+   fun:net.*
+}
+{
+   net/http
+   Memcheck:Addr8
+   fun:net/http.*
+}
+{
+   reflect
+   Memcheck:Addr8
+   fun:reflect.*
+}
+{
+   runtime
+   Memcheck:Addr1
+   fun:runtime.*
+}
+{
+   runtime
+   Memcheck:Addr4
+   fun:runtime.*
+}
+{
+   runtime
+   Memcheck:Addr8
+   fun:runtime.*
+}
+{
+   runtime
+   Memcheck:Addr16
+   fun:runtime.*
+}
+{
+   runtime
+   Memcheck:Addr32
+   fun:runtime.*
+}
+{
+   sync/*
+   Memcheck:Addr8
+   fun:sync/*
+}
+{
+   sync.*
+   Memcheck:Addr8
+   fun:sync.*
+}
+{
+   strconv
+   Memcheck:Addr8
+   fun:strconv.*
+}
+{
+   strings.EqualFold
+   Memcheck:Addr1
+   fun:strings.EqualFold
+}
+{
+   strings.EqualFold
+   Memcheck:Addr8
+   fun:strings.EqualFold
+}
+{
+   syscall.Read
+   Memcheck:Addr8
+   fun:syscall.Read
+}

--- a/test/valgrind.goruntime.supp
+++ b/test/valgrind.goruntime.supp
@@ -125,6 +125,11 @@
    fun:runtime.*
 }
 {
+   runtime
+   Memcheck:Cond
+   fun:runtime.*
+}
+{
    sync/*
    Memcheck:Addr8
    fun:sync/*

--- a/test/valgrind.goruntime.supp
+++ b/test/valgrind.goruntime.supp
@@ -4,6 +4,21 @@
    fun:bufio.*
 }
 {
+  bytes.*
+  Memcheck:Addr1
+  fun:bytes.*
+}
+{
+  bytes.*
+  Memcheck:Addr8
+  fun:bytes.*
+}
+{
+  context.*
+  Memcheck:Addr8
+  fun:context.*
+}
+{
    crypto
    Memcheck:Addr8
    fun:crypto/*
@@ -21,6 +36,7 @@
 {
    encoding
    Memcheck:Addr8
+   ...
    fun:encoding/*
 }
 {
@@ -31,17 +47,27 @@
 {
    internal
    Memcheck:Addr1
-   fun:internal/poll.*
+   fun:internal/*
 }
 {
    internal
    Memcheck:Addr8
-   fun:internal/poll.*
+   fun:internal/*
 }
 {
    io
    Memcheck:Addr8
    fun:io.*
+}
+{
+   net.*
+   Memcheck:Addr1
+   fun:net.*
+}
+{
+   net.*
+   Memcheck:Addr4
+   fun:net.*
 }
 {
    net.*
@@ -54,6 +80,16 @@
    fun:net/http.*
 }
 {
+   net/textproto
+   Memcheck:Addr1
+   fun:net/textproto.*
+}
+{
+   reflect
+   Memcheck:Addr1
+   fun:reflect.*
+}
+{
    reflect
    Memcheck:Addr8
    fun:reflect.*
@@ -61,6 +97,11 @@
 {
    runtime
    Memcheck:Addr1
+   fun:runtime.*
+}
+{
+   runtime
+   Memcheck:Addr2
    fun:runtime.*
 }
 {
@@ -90,8 +131,18 @@
 }
 {
    sync.*
+   Memcheck:Addr1
+   fun:sync.*
+}
+{
+   sync.*
    Memcheck:Addr8
    fun:sync.*
+}
+{
+   strconv
+   Memcheck:Addr1
+   fun:strconv.*
 }
 {
    strconv
@@ -99,17 +150,34 @@
    fun:strconv.*
 }
 {
-   strings.EqualFold
+   strings.*
    Memcheck:Addr1
-   fun:strings.EqualFold
+   fun:strings.*
 }
 {
-   strings.EqualFold
+   strings.*
    Memcheck:Addr8
-   fun:strings.EqualFold
+   fun:strings.*
+}
+{
+   syscall.anyToSockaddr
+   Memcheck:Addr1
+   fun:syscall.anyToSockaddr
 }
 {
    syscall.Read
    Memcheck:Addr8
    fun:syscall.Read
+}
+{
+   syscall.Syscall
+   Memcheck:Param
+   read(buf)
+   fun:syscall.Syscall
+}
+{
+   syscall.Syscall
+   Memcheck:Param
+   write(buf)
+   fun:syscall.Syscall
 }


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-cross/pull/1 to make tests pass (we need the valgrind package in the docker test images) :warning: 

# Description

Add [valgrind](http://valgrind.org/) on top of functional tests, automatically generating a report available at the following path: `test/_build_cpp_tests/valgrind_report.log`

Do not review any of the `*.supp` files: those are only rules asking valgrind to suppress detected issues. The aim of these files, at least for now, is only to suppress Go and CGo errors (see below).

# Go and CGo errors

Go and CGo issues detected by valgrind are irrelevant. If needed, dedicated profiling should be performed directly on those layers instead.

The valgrind report should hide most, if not all, Go and Cgo errors, thanks to the `valgrind.*.supp` suppression files stored in the `test/` directory.

If new errors appear from these 2 layers, then the suppression files should be amended accordingly, by using the suppression snippet provided in the valgrind report (more information in the [valgrind documentation](http://valgrind.org/docs/manual/manual-core.html#manual-core.suppress))

:warning: be wary when adding new suppression rules: not all warnings with a Go file in the stacktrace are to be suppressed. For instance, a memory leak report because of a calloc made in CGo will partly show Go files in the stacktrace, but the leak is real, in the C++ world, and must be fixed

# Valgrind report impact on the CI

For now, there are so many problems to be fixed that the valgrind report is informational only, and does not block the CI.
Having the report automatically generated will help us track the bugs to be fixed. Once all valgrind issues are solved, we'll have to parse the log file and block the CI if new issues are detected.

# Other changes

- The C SDK shared library is now used for cucumber, instead of the static one. This allows us to efficiently suppress most of the false positives from the CGo world. 
- ~A global "After" hook has been added to the cucumber test suite, executed after each scenario. This hook frees the instances of Kuzzle and Protocol in the global context, preventing meaningless memleak reports from valgrind~ (reverted, this causes a crash of currently unknown source with tests running on ARM 32 bits architecture)
- The "run_test" rule in the makefile now runs the `run-tests.sh` script, instead of having its own way of starting tests. This DRYifies the process and makes testing more consistent