### PR TITLE
Fix #37: standardize error handling and call the C destructors

### DIFF
--- a/include/internal/exceptions.hpp
+++ b/include/internal/exceptions.hpp
@@ -96,57 +96,39 @@ namespace kuzzleio {
     UnauthorizedException(const UnauthorizedException& ue) : KuzzleException(ue.status, ue.getMessage()) {}
   };
 
-  template <class T>
-  void throwExceptionFromStatus(T *result) {
-    const std::string error = std::string(result->error);
-    delete(result->error);
-    if (result->stack) {
-      free(const_cast<char *>(result->stack));
-    }
-
-    switch(result->status) {
+  static void throwKuzzleException(int status, const std::string& error) {
+    switch(status) {
       case PARTIAL_EXCEPTION:
-        delete(result);
         throw PartialException(error);
       break;
       case BAD_REQUEST_EXCEPTION:
-        delete(result);
         throw BadRequestException(error);
       break;
       case UNAUTHORIZED_EXCEPTION:
-        delete(result);
         throw UnauthorizedException(error);
       break;
       case FORBIDDEN_EXCEPTION:
-        delete(result);
         throw ForbiddenException(error);
       break;
       case NOT_FOUND_EXCEPTION:
-        delete(result);
         throw NotFoundException(error);
       break;
       case PRECONDITION_EXCEPTION:
-        delete(result);
         throw PreconditionException(error);
       break;
       case SIZE_LIMIT_EXCEPTION:
-        delete(result);
         throw SizeLimitException(error);
       break;
       case INTERNAL_EXCEPTION:
-        delete(result);
         throw InternalException(error);
       break;
       case SERVICE_UNAVAILABLE_EXCEPTION:
-        delete(result);
         throw ServiceUnavailableException(error);
       break;
       case GATEWAY_TIMEOUT_EXCEPTION:
-        delete(result);
         throw GatewayTimeoutException(error);
       break;
       default:
-        delete(result);
         throw KuzzleException(500, error);
     }
   }

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -35,6 +35,35 @@
 
 #include "internal/search_result.hpp"
 
+/*
+ * Macro used by controller actions.
+ * This standardizes and DRYifies the following process, making sure
+ * that the underlying API result structure is correctly
+ * freed when an error is received and when an exception
+ * has to be thrown:
+ *
+ * - call the <_call> function, usually a kuzzle cgo function (with args)
+ * - stores the result in a <_type> variable of name <_name>
+ * - if an error has been received:
+ *   - create an exception
+ *   - free the result structure
+ *   - throw the exception
+ *
+ * The last variadic parameter is a single line of code to be called
+ * after the API result has been received, but before the error handling.
+ * This is usually used to free intermediate variables instantiated to
+ * convert a C++ arg into a cgo-compatible one
+ */
+#define KUZZLE_API(_type, _name, _call, ... ) \
+  _type * _name = _call; \
+  __VA_ARGS__; \
+  if (_name != nullptr && _name->error != nullptr) {\
+    int status = _name->status; \
+    std::string err = _name->error; \
+    kuzzle_free_##_type(_name); \
+    throwKuzzleException(status, err); \
+  }
+
 namespace kuzzleio {
   class Collection;
   class Document;

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -91,10 +91,7 @@ namespace kuzzleio {
   std::vector<std::string> Auth::getStrategies(query_options *options) {
     KUZZLE_API(string_array_result, r, kuzzle_get_strategies(_auth, options))
 
-    std::vector<std::string> strategies;
-
-    for (size_t i = 0; i < r->result_length; ++i)
-      strategies.push_back(r->result[i]);
+    std::vector<std::string> strategies = std::vector<std::string>(r->result, r->result + r->result_length);
 
     kuzzle_free_string_array_result(r);
     return strategies;

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -38,34 +38,29 @@ namespace kuzzleio {
   }
 
   std::string Auth::createMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options) {
-    string_result* r = kuzzle_create_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options);
-    if (r->error)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_create_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options))
+
     std::string ret = r->result;
-    delete(r);
+
+    kuzzle_free_string_result(r);
     return ret;
   }
 
   bool Auth::credentialsExist(const std::string& strategy, query_options *options) {
-    bool_result* r = kuzzle_credentials_exist(_auth, const_cast<char*>(strategy.c_str()), options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(bool_result, r, kuzzle_credentials_exist(_auth, const_cast<char*>(strategy.c_str()), options))
+
     bool ret = r->result;
-    delete(r);
+    kuzzle_free_bool_result(r);
     return ret;
   }
 
   void Auth::deleteMyCredentials(const std::string& strategy, query_options *options) {
-    error_result *r = kuzzle_delete_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options);
-    if (r != nullptr)
-        throwExceptionFromStatus(r);
-    delete(r);
+    KUZZLE_API(error_result, r, kuzzle_delete_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options))
+    kuzzle_free_error_result(r);
   }
 
   kuzzle_user* Auth::getCurrentUser() {
-    user_result *r = kuzzle_get_current_user(_auth);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(user_result, r, kuzzle_get_current_user(_auth))
 
     kuzzle_user *u = r->result;
     kuzzle_free_user_result(r);
@@ -73,23 +68,20 @@ namespace kuzzleio {
   }
 
   std::string Auth::getMyCredentials(const std::string& strategy, query_options *options) {
-    string_result *r = kuzzle_get_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_get_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
     return ret;
   }
 
   std::vector<user_right*> Auth::getMyRights(query_options* options) {
-    user_rights_result *r = kuzzle_get_my_rights(_auth, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(user_rights_result, r, kuzzle_get_my_rights(_auth, options))
 
     std::vector<user_right*> user_rights;
 
-    for (size_t i = 0; r->result[i]; ++i) {
-      user_rights.push_back(r->result[i]);
+    for (size_t i = 0; i < r->rights_length; ++i) {
+      user_rights.push_back(r->rights[i]);
     }
 
     kuzzle_free_user_rights_result(r);
@@ -97,13 +89,11 @@ namespace kuzzleio {
   }
 
   std::vector<std::string> Auth::getStrategies(query_options *options) {
-    string_array_result *r = kuzzle_get_strategies(_auth, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_array_result, r, kuzzle_get_strategies(_auth, options))
 
     std::vector<std::string> strategies;
 
-    for (size_t i = 0; r->result[i]; ++i)
+    for (size_t i = 0; i < r->result_length; ++i)
       strategies.push_back(r->result[i]);
 
     kuzzle_free_string_array_result(r);
@@ -111,18 +101,16 @@ namespace kuzzleio {
   }
 
   std::string Auth::login(const std::string& strategy, const std::string& credentials) {
-    string_result* r = kuzzle_login(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), nullptr);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_login(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), nullptr))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
     return ret;
   }
 
   std::string Auth::login(const std::string& strategy, const std::string& credentials, int expires_in) {
-    string_result* r = kuzzle_login(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), &expires_in);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_login(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), &expires_in))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
     return ret;
@@ -137,30 +125,26 @@ namespace kuzzleio {
   }
 
   std::string Auth::updateMyCredentials(const std::string& strategy, const std::string& credentials, query_options *options) {
-    string_result *r = kuzzle_update_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_update_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
     return ret;
   }
 
   kuzzle_user* Auth::updateSelf(const std::string& content, query_options* options) {
-    user_result *r = kuzzle_update_self(_auth, const_cast<char*>(content.c_str()), options);
-    if (r->error != nullptr)
-      throwExceptionFromStatus(r);
+    KUZZLE_API(user_result, r, kuzzle_update_self(_auth, const_cast<char*>(content.c_str()), options))
+
     kuzzle_user *ret = r->result;
     kuzzle_free_user_result(r);
     return ret;
   }
 
   bool Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options) {
-    bool_result *r = kuzzle_validate_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(bool_result, r, kuzzle_validate_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options))
+
     bool ret = r->result;
     kuzzle_free_bool_result(r);
     return ret;
   }
-
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -16,124 +16,98 @@
 #include "internal/collection.hpp"
 
 namespace kuzzleio {
-    Collection::Collection(Kuzzle* kuzzle) {
-        _collection = new collection();
-        kuzzle_new_collection(_collection, kuzzle->_kuzzle);
-    }
+  Collection::Collection(Kuzzle* kuzzle) {
+    _collection = new collection();
+    kuzzle_new_collection(_collection, kuzzle->_kuzzle);
+  }
 
-    Collection::Collection(Kuzzle* kuzzle, collection *collection) {
-        _collection = collection;
-        kuzzle_new_collection(collection, kuzzle->_kuzzle);
-    }
+  Collection::Collection(Kuzzle* kuzzle, collection *collection) {
+    _collection = collection;
+    kuzzle_new_collection(collection, kuzzle->_kuzzle);
+  }
 
-    Collection::~Collection() {
-        unregisterCollection(_collection);
-        delete(_collection);
-    }
+  Collection::~Collection() {
+    unregisterCollection(_collection);
+    delete(_collection);
+  }
 
-    void Collection::create(const std::string& index, const std::string& collection, const std::string* body, query_options *options) {
-        error_result *r = kuzzle_collection_create(
-            _collection,
-            const_cast<char*>(index.c_str()),
-            const_cast<char*>(collection.c_str()),
-            body != nullptr ? const_cast<char*>(body->c_str()) : nullptr,
-            options);
+  void Collection::create(const std::string& index, const std::string& collection, const std::string* body, query_options *options) {
+    char * bodystr = body != nullptr ? const_cast<char*>(body->c_str()) : nullptr;
+    KUZZLE_API(error_result, r, kuzzle_collection_create(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      bodystr,
+      options))
 
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
+    kuzzle_free_error_result(r);
+  }
 
-        kuzzle_free_error_result(r);
-    }
+  bool Collection::exists(const std::string& index, const std::string& collection, query_options *options) {
+    KUZZLE_API(bool_result, r, kuzzle_collection_exists(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
 
-    bool Collection::exists(const std::string& index, const std::string& collection, query_options *options) {
-        bool_result *r = kuzzle_collection_exists(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
+    bool ret = r->result;
+    kuzzle_free_bool_result(r);
+    return ret;
+  }
 
-        bool ret = r->result;
-        kuzzle_free_bool_result(r);
-        return ret;
-    }
+  std::string Collection::list(const std::string& index, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_list(_collection, const_cast<char*>(index.c_str()), options))
 
-    std::string Collection::list(const std::string& index, query_options *options) {
-        string_result *r = kuzzle_collection_list(_collection, const_cast<char*>(index.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
 
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
+  void Collection::truncate(const std::string& index, const std::string& collection, query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_collection_truncate(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
+    kuzzle_free_error_result(r);
+  }
 
-    void Collection::truncate(const std::string& index, const std::string& collection, query_options *options) {
-        error_result *r = kuzzle_collection_truncate(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
+  std::string Collection::getMapping(const std::string& index, const std::string& collection, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_get_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
 
-        kuzzle_free_error_result(r);
-    }
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
 
-    std::string Collection::getMapping(const std::string& index, const std::string& collection, query_options *options) {
-        string_result *r = kuzzle_collection_get_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
+    return ret;
+  }
 
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
+  void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_collection_update_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+    kuzzle_free_error_result(r);
+  }
 
-        return ret;
-    }
+  std::string Collection::getSpecifications(const std::string& index, const std::string& collection, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_get_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
 
-    void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        error_result *r = kuzzle_collection_update_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
 
-        kuzzle_free_error_result(r);
-    }
+    return ret;
+  }
 
-    std::string Collection::getSpecifications(const std::string& index, const std::string& collection, query_options *options) {
-        string_result *r = kuzzle_collection_get_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
+  SearchResult* Collection::searchSpecifications(const std::string& body, query_options *options) {
+    KUZZLE_API(search_result, r, kuzzle_collection_search_specifications(_collection, const_cast<char*>(body.c_str()), options))
+    return new SearchResult(r);
+  }
 
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
+  std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_update_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options))
 
-        return ret;
-    }
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
 
-    SearchResult* Collection::searchSpecifications(const std::string& body, query_options *options) {
-        search_result *r = kuzzle_collection_search_specifications(_collection, const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
+    return ret;
+  }
 
-        return new SearchResult(r);
-    }
+  validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
+    KUZZLE_API(validation_response, r, kuzzle_collection_validate_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options))
+    return r;
+  }
 
-    std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
-        string_result *r = kuzzle_collection_update_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-
-        return ret;
-    }
-
-    validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
-        validation_response *r = kuzzle_collection_validate_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        return r;
-    }
-
-    void Collection::deleteSpecifications(const std::string& index, const std::string& collection, query_options *options) {
-        error_result *r = kuzzle_collection_delete_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options);
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
-
-        kuzzle_free_error_result(r);
-    }
+  void Collection::deleteSpecifications(const std::string& index, const std::string& collection, query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_collection_delete_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
+    kuzzle_free_error_result(r);
+  }
 }

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -33,7 +33,7 @@ namespace kuzzleio {
   }
 
   int Document::count(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    char* rbody = NULL;
+    char* rbody = nullptr;
 
     if (!body.empty()) {
         rbody = const_cast<char*>(body.c_str());
@@ -85,10 +85,7 @@ namespace kuzzleio {
   std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
     KUZZLE_API(string_array_result, r, kuzzle_document_delete_by_query(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
 
-    std::vector<std::string> v;
-    for (int i = 0; i < r->result_length; i++)
-      v.push_back(r->result[i]);
-
+    std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
     return v;
   }
@@ -148,10 +145,8 @@ namespace kuzzleio {
 
   std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
     char **idsArray = new char *[ids.size()];
-    int i = 0;
-    for (auto& id : ids) {
-      idsArray[i] = const_cast<char*>(id.c_str());
-      i++;
+    for (size_t i = 0; i < ids.size(); i++) {
+      idsArray[i] = const_cast<char*>(ids[i].c_str());
     }
 
     KUZZLE_API(
@@ -160,20 +155,15 @@ namespace kuzzleio {
       kuzzle_document_mdelete(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), idsArray, ids.size(), options),
       delete[] idsArray)
 
-    std::vector<std::string> v;
-    for (int j = 0; j < r->result_length; j++)
-      v.push_back(r->result[j]);
-
+    std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
     return v;
   }
 
   std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
     char **idsArray = new char *[ids.size()];
-    int i = 0;
-    for (auto& id : ids) {
-      idsArray[i] = const_cast<char*>(id.c_str());
-      i++;
+    for (size_t i = 0; i < ids.size(); i++) {
+      idsArray[i] = const_cast<char*>(ids[i].c_str());
     }
 
     KUZZLE_API(

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// 		http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,221 +17,189 @@
 #include "internal/search_result.hpp"
 
 namespace kuzzleio {
-    Document::Document(Kuzzle* kuzzle) {
-        _document = new document();
-        kuzzle_new_document(_document, kuzzle->_kuzzle);
+  Document::Document(Kuzzle* kuzzle) {
+    _document = new document();
+    kuzzle_new_document(_document, kuzzle->_kuzzle);
+  }
+
+  Document::Document(Kuzzle* kuzzle, document *document) {
+    _document = document;
+    kuzzle_new_document(_document, kuzzle->_kuzzle);
+  }
+
+  Document::~Document() {
+    unregisterDocument(_document);
+    delete(_document);
+  }
+
+  int Document::count(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    char* rbody = NULL;
+
+    if (!body.empty()) {
+        rbody = const_cast<char*>(body.c_str());
     }
 
-    Document::Document(Kuzzle* kuzzle, document *document) {
-        _document = document;
-        kuzzle_new_document(_document, kuzzle->_kuzzle);
+    KUZZLE_API(int_result, r, kuzzle_document_count(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), rbody, options))
+
+    int ret = r->result;
+    kuzzle_free_int_result(r);
+    return ret;
+  }
+
+  int Document::count(const std::string& index, const std::string& collection, query_options *options) {
+    return count(index, collection, "", options);
+  }
+
+  bool Document::exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
+    KUZZLE_API(bool_result, r, kuzzle_document_exists(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options))
+
+    bool ret = r->result;
+    kuzzle_free_bool_result(r);
+    return ret;
+  }
+
+  std::string Document::create(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_create(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  std::string Document::createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_create_or_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  std::string Document::delete_(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_delete(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(string_array_result, r, kuzzle_document_delete_by_query(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+    std::vector<std::string> v;
+    for (int i = 0; i < r->result_length; i++)
+      v.push_back(r->result[i]);
+
+    kuzzle_free_string_array_result(r);
+    return v;
+  }
+
+  std::string Document::get(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_get(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  std::string Document::replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  std::string Document::update(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_update(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  bool Document::validate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(bool_result, r, kuzzle_document_validate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+    bool ret = r->result;
+    kuzzle_free_bool_result(r);
+    return ret;
+  }
+
+  SearchResult* Document::search(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(search_result, r, kuzzle_document_search(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+    return new SearchResult(r);
+  }
+
+  std::string Document::mCreate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mcreate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  std::string Document::mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mcreate_or_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
+
+  std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
+    char **idsArray = new char *[ids.size()];
+    int i = 0;
+    for (auto& id : ids) {
+      idsArray[i] = const_cast<char*>(id.c_str());
+      i++;
     }
 
-    Document::~Document() {
-        unregisterDocument(_document);
-        delete(_document);
+    KUZZLE_API(
+      string_array_result,
+      r,
+      kuzzle_document_mdelete(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), idsArray, ids.size(), options),
+      delete[] idsArray)
+
+    std::vector<std::string> v;
+    for (int j = 0; j < r->result_length; j++)
+      v.push_back(r->result[j]);
+
+    kuzzle_free_string_array_result(r);
+    return v;
+  }
+
+  std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
+    char **idsArray = new char *[ids.size()];
+    int i = 0;
+    for (auto& id : ids) {
+      idsArray[i] = const_cast<char*>(id.c_str());
+      i++;
     }
 
-    int Document::count(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        char* rbody;
+    KUZZLE_API(
+      string_result,
+      r,
+      kuzzle_document_mget(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), idsArray, ids.size(), options),
+      delete[] idsArray)
 
-        if (!body.empty()) {
-            rbody = const_cast<char*>(body.c_str());
-        }
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
 
-        int_result *r = kuzzle_document_count(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), rbody, options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-        int ret = r->result;
-        kuzzle_free_int_result(r);
-        return ret;
-    }
+  std::string Document::mReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mreplace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
 
-    int Document::count(const std::string& index, const std::string& collection, query_options *options) {
-        return count(index, collection, "", options);
-    }
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
 
-    bool Document::exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
-        bool_result *r = kuzzle_document_exists(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
+  std::string Document::mUpdate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mupdate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
 
-        bool ret = r->result;
-        kuzzle_free_bool_result(r);
-        return ret;
-    }
-
-    std::string Document::create(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_create(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::string Document::createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_create_or_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::string Document::delete_(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
-        string_result *r = kuzzle_document_delete(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        string_array_result *r = kuzzle_document_delete_by_query(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-
-        if (r->error != nullptr)
-          throwExceptionFromStatus(r);
-
-        std::vector<std::string> v;
-        for (int i = 0; i < r->result_length; i++)
-          v.push_back(r->result[i]);
-
-        kuzzle_free_string_array_result(r);
-        return v;
-    }
-
-    std::string Document::get(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
-        string_result *r = kuzzle_document_get(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::string Document::replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::string Document::update(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_update(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    bool Document::validate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        bool_result *r = kuzzle_document_validate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        bool ret = r->result;
-        kuzzle_free_bool_result(r);
-        return ret;
-    }
-
-    SearchResult* Document::search(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        search_result *r = kuzzle_document_search(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        return new SearchResult(r);
-    }
-
-    std::string Document::mCreate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_mcreate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-          throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::string Document::mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_mcreate_or_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-          throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
-        char **idsArray = new char *[ids.size()];
-        int i = 0;
-        for (auto& id : ids) {
-          idsArray[i] = const_cast<char*>(id.c_str());
-          i++;
-        }
-
-        string_array_result *r = kuzzle_document_mdelete(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), idsArray, ids.size(), options);
-        delete[] idsArray;
-        if (r->error != nullptr) {
-          fflush(NULL);
-          throwExceptionFromStatus(r);
-        }
-
-        std::vector<std::string> v;
-        for (int i = 0; i < r->result_length; i++)
-          v.push_back(r->result[i]);
-
-        kuzzle_free_string_array_result(r);
-        return v;
-    }
-
-    std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
-        char **idsArray = new char *[ids.size()];
-        int i = 0;
-        for (auto& id : ids) {
-          idsArray[i] = const_cast<char*>(id.c_str());
-          i++;
-        }
-
-        string_result *r = kuzzle_document_mget(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), idsArray, ids.size(), options);
-        delete[] idsArray;
-        if (r->error != nullptr)
-          throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-
-    }
-    std::string Document::mReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_mreplace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-          throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
-    std::string Document::mUpdate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-        string_result *r = kuzzle_document_mupdate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-        if (r->error != nullptr)
-          throwExceptionFromStatus(r);
-
-        std::string ret = r->result;
-        kuzzle_free_string_result(r);
-        return ret;
-    }
-
+    std::string ret = r->result;
+    kuzzle_free_string_result(r);
+    return ret;
+  }
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -43,10 +43,8 @@ namespace kuzzleio {
 
   std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes, query_options *options) {
     char **indexesArray = new char *[indexes.size()];
-    int i = 0;
-    for (auto& index : indexes) {
-      indexesArray[i] = const_cast<char*>(index.c_str());
-      i++;
+    for (size_t i = 0; i < indexes.size(); i++) {
+      indexesArray[i] = const_cast<char*>(indexes[i].c_str());
     }
 
     KUZZLE_API(
@@ -56,10 +54,7 @@ namespace kuzzleio {
       delete[] indexesArray
     )
 
-    std::vector<std::string> v;
-    for (int i = 0; i < r->result_length; i++)
-      v.push_back(r->result[i]);
-
+    std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
     return v;
   }
@@ -98,10 +93,7 @@ namespace kuzzleio {
   std::vector<std::string> Index::list(query_options *options) {
     KUZZLE_API(string_array_result, r, kuzzle_index_list(_index, options))
 
-    std::vector<std::string> v;
-    for (int i = 0; i < r->result_length; i++)
-      v.push_back(r->result[i]);
-
+    std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
     return v;
   }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// 		http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,106 +16,93 @@
 #include "internal/index.hpp"
 
 namespace kuzzleio {
+  Index::Index(Kuzzle* kuzzle) {
+    _index = new kuzzle_index();
+    kuzzle_new_index(_index, kuzzle->_kuzzle);
+  }
 
-    Index::Index(Kuzzle* kuzzle) {
-        _index = new kuzzle_index();
-        kuzzle_new_index(_index, kuzzle->_kuzzle);
+  Index::Index(Kuzzle* kuzzle, kuzzle_index *index) {
+    _index = index;
+    kuzzle_new_index(index, kuzzle->_kuzzle);
+  }
+
+  Index::~Index() {
+    unregisterIndex(_index);
+    delete(_index);
+  }
+
+  void Index::create(const std::string& index, query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_index_create(_index, const_cast<char*>(index.c_str()), options))
+    kuzzle_free_error_result(r);
+  }
+
+  void Index::delete_(const std::string& index, query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_index_delete(_index, const_cast<char*>(index.c_str()), options))
+    kuzzle_free_error_result(r);
+  }
+
+  std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes, query_options *options) {
+    char **indexesArray = new char *[indexes.size()];
+    int i = 0;
+    for (auto& index : indexes) {
+      indexesArray[i] = const_cast<char*>(index.c_str());
+      i++;
     }
 
-    Index::Index(Kuzzle* kuzzle, kuzzle_index *index) {
-      _index = index;
-      kuzzle_new_index(index, kuzzle->_kuzzle);
-    }
+    KUZZLE_API(
+      string_array_result,
+      r,
+      kuzzle_index_mdelete(_index, indexesArray, indexes.size(), options),
+      delete[] indexesArray
+    )
 
-    Index::~Index() {
-        unregisterIndex(_index);
-        delete(_index);
-    }
+    std::vector<std::string> v;
+    for (int i = 0; i < r->result_length; i++)
+      v.push_back(r->result[i]);
 
-    void Index::create(const std::string& index, query_options *options) {
-        error_result *r = kuzzle_index_create(_index, const_cast<char*>(index.c_str()), options);
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
-        kuzzle_free_error_result(r);
-    }
+    kuzzle_free_string_array_result(r);
+    return v;
+  }
 
-    void Index::delete_(const std::string& index, query_options *options) {
-        error_result *r = kuzzle_index_delete(_index, const_cast<char*>(index.c_str()), options);
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
-        kuzzle_free_error_result(r);
-    }
+  bool Index::exists(const std::string& index, query_options *options) {
+    KUZZLE_API(bool_result, r, kuzzle_index_exists(_index, const_cast<char*>(index.c_str()), options))
 
-    std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes, query_options *options) {
-        char **indexesArray = new char *[indexes.size()];
-        int i = 0;
-        for (auto& index : indexes) {
-          indexesArray[i] = const_cast<char*>(index.c_str());
-          i++;
-        }
-        string_array_result *r = kuzzle_index_mdelete(_index, indexesArray, indexes.size(), options);
+    bool ret = r->result;
+    kuzzle_free_bool_result(r);
+    return ret;
+  }
 
-        delete[] indexesArray;
-        if (r->error != nullptr)
-          throwExceptionFromStatus(r);
+  void Index::refresh(const std::string& index, query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_index_refresh(_index, const_cast<char*>(index.c_str()), options))
+    kuzzle_free_error_result(r);
+  }
 
-        std::vector<std::string> v;
-        for (int i = 0; i < r->result_length; i++)
-          v.push_back(r->result[i]);
+  void Index::refreshInternal(query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_index_refresh_internal(_index, options))
+    kuzzle_free_error_result(r);
+  }
 
-        kuzzle_free_string_array_result(r);
-        return v;
-    }
+  void Index::setAutoRefresh(const std::string& index, bool autoRefresh, query_options *options) {
+    KUZZLE_API(error_result, r, kuzzle_index_set_auto_refresh(_index, const_cast<char*>(index.c_str()), autoRefresh, options))
+    kuzzle_free_error_result(r);
+  }
 
-    bool Index::exists(const std::string& index, query_options *options) {
-        bool_result *r = kuzzle_index_exists(_index, const_cast<char*>(index.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-        bool ret = r->result;
-        kuzzle_free_bool_result(r);
-        return ret;
-    }
+  bool Index::getAutoRefresh(const std::string& index, query_options *options) {
+    KUZZLE_API(bool_result, r, kuzzle_index_get_auto_refresh(_index, const_cast<char*>(index.c_str()), options))
 
-    void Index::refresh(const std::string& index, query_options *options) {
-        error_result *r = kuzzle_index_refresh(_index, const_cast<char*>(index.c_str()), options);
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
-        kuzzle_free_error_result(r);
-    }
+    bool ret = r->result;
+    kuzzle_free_bool_result(r);
+    return ret;
+  }
 
-    void Index::refreshInternal(query_options *options) {
-        error_result *r = kuzzle_index_refresh_internal(_index, options);
-        if (r != nullptr)
-            throwExceptionFromStatus(r);
-        kuzzle_free_error_result(r);
-    }
+  std::vector<std::string> Index::list(query_options *options) {
+    KUZZLE_API(string_array_result, r, kuzzle_index_list(_index, options))
 
-    void Index::setAutoRefresh(const std::string& index, bool autoRefresh, query_options *options) {
-      error_result *r = kuzzle_index_set_auto_refresh(_index, const_cast<char*>(index.c_str()), autoRefresh, options);
-      if (r != nullptr)
-          throwExceptionFromStatus(r);
-        kuzzle_free_error_result(r);
-    }
+    std::vector<std::string> v;
+    for (int i = 0; i < r->result_length; i++)
+      v.push_back(r->result[i]);
 
-    bool Index::getAutoRefresh(const std::string& index, query_options *options) {
-        bool_result *r = kuzzle_index_get_auto_refresh(_index, const_cast<char*>(index.c_str()), options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-        bool ret = r->result;
-        kuzzle_free_bool_result(r);
-        return ret;
-    }
-
-    std::vector<std::string> Index::list(query_options *options) {
-        string_array_result *r = kuzzle_index_list(_index, options);
-        if (r->error != nullptr)
-            throwExceptionFromStatus(r);
-
-        std::vector<std::string> v;
-        for (int i = 0; i < r->result_length; i++)
-          v.push_back(r->result[i]);
-
-        kuzzle_free_string_array_result(r);
-        return v;
-    }
+    kuzzle_free_string_array_result(r);
+    return v;
+  }
 }

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -192,10 +192,7 @@ namespace kuzzleio {
   }
 
   kuzzle_response* Kuzzle::query(kuzzle_request* query, query_options* options) {
-    kuzzle_response *r = kuzzle_query(_kuzzle, query, options);
-
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(kuzzle_response, r, kuzzle_query(_kuzzle, query, options))
     return r;
   }
 

--- a/src/realtime.cpp
+++ b/src/realtime.cpp
@@ -32,9 +32,11 @@ namespace kuzzleio {
   }
 
   int Realtime::count(const std::string& roomId, query_options *options) {
-    int_result *r = kuzzle_realtime_count(_realtime, const_cast<char*>(roomId.c_str()), options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(
+      int_result,
+      r,
+      kuzzle_realtime_count(_realtime, const_cast<char*>(roomId.c_str()), options))
+
     int ret = r->result;
     kuzzle_free_int_result(r);
     return ret;
@@ -55,16 +57,19 @@ namespace kuzzleio {
   }
 
   void Realtime::publish(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    error_result *r = kuzzle_realtime_publish(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options);
-    if (r != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(
+      error_result,
+      r,
+      kuzzle_realtime_publish(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
     kuzzle_free_error_result(r);
   }
 
   std::string Realtime::subscribe(const std::string& index, const std::string& collection, const std::string& body, NotificationListener* cb, room_options* options) {
-    subscribe_result *r = kuzzle_realtime_subscribe(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()),  const_cast<char*>(body.c_str()), call_subscribe_cb, this, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(
+      subscribe_result,
+      r,
+      kuzzle_realtime_subscribe(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()),  const_cast<char*>(body.c_str()), call_subscribe_cb, this, options))
 
     std::string roomId = r->room;
     std::string channel = r->channel;
@@ -75,9 +80,10 @@ namespace kuzzleio {
   }
 
   void Realtime::unsubscribe(const std::string& roomId, query_options *options) {
-    error_result *r = kuzzle_realtime_unsubscribe(_realtime, const_cast<char*>(roomId.c_str()), options);
-    if (r != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(
+      error_result,
+      r,
+      kuzzle_realtime_unsubscribe(_realtime, const_cast<char*>(roomId.c_str()), options))
 
     _listener_instances[roomId] = nullptr;
     kuzzle_free_error_result(r);

--- a/src/realtime.cpp
+++ b/src/realtime.cpp
@@ -72,9 +72,7 @@ namespace kuzzleio {
       kuzzle_realtime_subscribe(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()),  const_cast<char*>(body.c_str()), call_subscribe_cb, this, options))
 
     std::string roomId = r->room;
-    std::string channel = r->channel;
-
-    _listener_instances[channel] = cb;
+    _listener_instances[r->channel] = cb;
     kuzzle_free_subscribe_result(r);
     return roomId;
   }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -17,82 +17,69 @@
 
 namespace kuzzleio {
   Server::Server(Kuzzle* kuzzle) {
-      _server = new server();
-      kuzzle_new_server(_server, kuzzle->_kuzzle);
+    _server = new server();
+    kuzzle_new_server(_server, kuzzle->_kuzzle);
   }
 
   Server::Server(Kuzzle* kuzzle, server *server) {
-      _server = server;
-      kuzzle_new_server(_server, kuzzle->_kuzzle);
+    _server = server;
+    kuzzle_new_server(_server, kuzzle->_kuzzle);
   }
 
   Server::~Server() {
-      unregisterServer(_server);
-      delete(_server);
+    unregisterServer(_server);
+    delete(_server);
   }
 
   bool Server::adminExists(query_options *options) {
-    bool_result* r = kuzzle_admin_exists(_server, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(bool_result, r, kuzzle_admin_exists(_server, options))
     bool ret = r->result;
-    delete(r);
+    kuzzle_free_bool_result(r);
     return ret;
   }
 
   std::string Server::getAllStats(query_options* options) {
-    string_result* r = kuzzle_get_all_stats(_server, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_get_all_stats(_server, options))
     std::string ret = r->result;
-    delete(r);
+    kuzzle_free_string_result(r);
     return ret;
   }
 
   std::string Server::getStats(time_t start, time_t end, query_options* options) {
-    string_result* r = kuzzle_get_stats(_server, start, end, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_get_stats(_server, start, end, options))
     std::string ret = r->result;
-    delete(r);
+    kuzzle_free_string_result(r);
     return ret;
   }
 
   std::string Server::getLastStats(query_options* options) {
-    string_result* r = kuzzle_get_last_stats(_server, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_get_last_stats(_server, options))
     std::string ret = r->result;
-    delete(r);
+    kuzzle_free_string_result(r);
     return ret;
   }
 
   std::string Server::getConfig(query_options* options) {
-    string_result* r = kuzzle_get_config(_server, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_get_config(_server, options))
     std::string ret = r->result;
-    delete(r);
+    kuzzle_free_string_result(r);
     return ret;
   }
 
   std::string Server::info(query_options* options) {
-    string_result* r = kuzzle_info(_server, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(string_result, r, kuzzle_info(_server, options))
+
     std::string ret = r->result;
-    delete(r);
+    kuzzle_free_string_result(r);
     return ret;
   }
 
   // java wrapper for this method is in typemap.i
   long long Server::now(query_options* options) {
-    date_result *r = kuzzle_now(_server, options);
-    if (r->error != nullptr)
-        throwExceptionFromStatus(r);
+    KUZZLE_API(date_result, r, kuzzle_now(_server, options))
+
     long long ret = r->result;
-    delete(r);
+    kuzzle_free_date_result(r);
     return ret;
   }
-
 }

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -1,149 +1,148 @@
 #include "websocket.hpp"
 
 namespace kuzzleio {
+  WebSocket::WebSocket(const std::string& host, options *opts) {
+    this->_web_socket = new web_socket();
 
-    WebSocket::WebSocket(const std::string& host, options *opts) {
-      this->_web_socket = new web_socket();
+    kuzzle_websocket_new_web_socket(this->_web_socket, const_cast<char*>(host.c_str()), opts, this);
+  }
 
-      kuzzle_websocket_new_web_socket(this->_web_socket, const_cast<char*>(host.c_str()), opts, this);
-    }
-
-    void trigger_websocket_event_listener(int event, char* res, void* data) {
-      std::list<EventListener*> listeners = static_cast<WebSocket*>(data)->getListeners(event);
-      if (listeners.size()) {
-        for (EventListener*& listener : listeners) {
-          (*listener)(res);
-        }
+  void trigger_websocket_event_listener(int event, char* res, void* data) {
+    std::list<EventListener*> listeners = static_cast<WebSocket*>(data)->getListeners(event);
+    if (listeners.size()) {
+      for (EventListener*& listener : listeners) {
+        (*listener)(res);
       }
     }
+  }
 
-    void trigger_websocket_once(int event, char* res, void* data) {
-      std::list<EventListener*> listeners = static_cast<WebSocket*>(data)->getOnceListeners(event);
-      if (listeners.size()) {
-        for (EventListener*& listener : listeners) {
-          (*listener)(res);
-          static_cast<WebSocket*>(data)->getOnceListeners(event).remove(listener);
-        }
+  void trigger_websocket_once(int event, char* res, void* data) {
+    std::list<EventListener*> listeners = static_cast<WebSocket*>(data)->getOnceListeners(event);
+    if (listeners.size()) {
+      for (EventListener*& listener : listeners) {
+        (*listener)(res);
+        static_cast<WebSocket*>(data)->getOnceListeners(event).remove(listener);
       }
     }
+  }
 
-    void trigger_websocket_notification_listener(notification_result* result, void* data) {
-      NotificationListener* listener = static_cast<WebSocket*>(data)->getNotificationListener(result->room_id);
-      if (listener) {
-        (*listener)(result);
-      }
+  void trigger_websocket_notification_listener(notification_result* result, void* data) {
+    NotificationListener* listener = static_cast<WebSocket*>(data)->getNotificationListener(result->room_id);
+    if (listener) {
+      (*listener)(result);
     }
+  }
 
-    std::list<EventListener*> WebSocket::getListeners(int event) noexcept {
-      return _websocket_listener_instances[event];
-    }
+  std::list<EventListener*> WebSocket::getListeners(int event) noexcept {
+    return _websocket_listener_instances[event];
+  }
 
-    std::list<EventListener*> WebSocket::getOnceListeners(int event) noexcept {
-      return _websocket_once_listener_instances[event];
-    }
+  std::list<EventListener*> WebSocket::getOnceListeners(int event) noexcept {
+    return _websocket_once_listener_instances[event];
+  }
 
-    NotificationListener* WebSocket::getNotificationListener(const std::string& room_id) noexcept {
-      return _websocket_notification_listener_instances[room_id];
-    }
+  NotificationListener* WebSocket::getNotificationListener(const std::string& room_id) noexcept {
+    return _websocket_notification_listener_instances[room_id];
+  }
 
-    void WebSocket::addListener(Event event, EventListener* listener) {
-      _websocket_listener_instances[event].push_back(listener);
-      kuzzle_websocket_add_listener(this->_web_socket, event, trigger_websocket_event_listener);
-    }
+  void WebSocket::addListener(Event event, EventListener* listener) {
+    _websocket_listener_instances[event].push_back(listener);
+    kuzzle_websocket_add_listener(this->_web_socket, event, trigger_websocket_event_listener);
+  }
 
-    void WebSocket::removeListener(Event event, EventListener* listener) {
-      _websocket_listener_instances[event].remove(listener);
-    }
+  void WebSocket::removeListener(Event event, EventListener* listener) {
+    _websocket_listener_instances[event].remove(listener);
+  }
 
-    void WebSocket::removeAllListeners(Event event) {
-      kuzzle_websocket_remove_all_listeners(this->_web_socket, event);
-      _websocket_listener_instances[event].clear();
-    }
+  void WebSocket::removeAllListeners(Event event) {
+    kuzzle_websocket_remove_all_listeners(this->_web_socket, event);
+    _websocket_listener_instances[event].clear();
+  }
 
-    void WebSocket::once(Event event, EventListener* listener) {
-      _websocket_once_listener_instances[event].push_back(listener);
-      kuzzle_websocket_once(this->_web_socket, event, trigger_websocket_once);
-    }
+  void WebSocket::once(Event event, EventListener* listener) {
+    _websocket_once_listener_instances[event].push_back(listener);
+    kuzzle_websocket_once(this->_web_socket, event, trigger_websocket_once);
+  }
 
-    int WebSocket::listenerCount(Event event) {
-      return kuzzle_websocket_listener_count(this->_web_socket, event);
-    }
+  int WebSocket::listenerCount(Event event) {
+    return kuzzle_websocket_listener_count(this->_web_socket, event);
+  }
 
-    char* WebSocket::connect() {
-      return kuzzle_websocket_connect(this->_web_socket);
-    }
+  char* WebSocket::connect() {
+    return kuzzle_websocket_connect(this->_web_socket);
+  }
 
-    kuzzle_response* WebSocket::send(const std::string& query, query_options *options, const std::string& request_id) {
-      kuzzle_response* res = kuzzle_websocket_send(this->_web_socket, const_cast<char*>(query.c_str()), options, const_cast<char*>(request_id.c_str()));
-      return res;
-    }
+  kuzzle_response* WebSocket::send(const std::string& query, query_options *options, const std::string& request_id) {
+    kuzzle_response* res = kuzzle_websocket_send(this->_web_socket, const_cast<char*>(query.c_str()), options, const_cast<char*>(request_id.c_str()));
+    return res;
+  }
 
-    std::string WebSocket::close() {
-      const char* res = kuzzle_websocket_close(this->_web_socket);
-      if (res) {
-        return std::string(kuzzle_websocket_close(this->_web_socket));
-      }
-      return "";
+  std::string WebSocket::close() {
+    const char* res = kuzzle_websocket_close(this->_web_socket);
+    if (res) {
+      return std::string(res);
     }
+    return "";
+  }
 
-    int WebSocket::getState() {
-      return kuzzle_websocket_get_state(this->_web_socket);
-    }
-    
-    void WebSocket::emitEvent(Event event) {
-      kuzzle_websocket_emit_event(this->_web_socket, event, nullptr);
-    }
+  int WebSocket::getState() {
+    return kuzzle_websocket_get_state(this->_web_socket);
+  }
 
-    void WebSocket::registerSub(const std::string& channel, const std::string& room_id, const std::string& filters, bool subscribe_to_self, NotificationListener* listener) {
-      _websocket_notification_listener_instances[channel] = listener;
-      kuzzle_websocket_register_sub(this->_web_socket, const_cast<char*>(channel.c_str()), const_cast<char*>(room_id.c_str()), const_cast<char*>(filters.c_str()), subscribe_to_self, trigger_websocket_notification_listener);
-    }
+  void WebSocket::emitEvent(Event event) {
+    kuzzle_websocket_emit_event(this->_web_socket, event, nullptr);
+  }
 
-    void WebSocket::unregisterSub(const std::string& id) {
-      kuzzle_websocket_unregister_sub(this->_web_socket, const_cast<char*>(id.c_str()));
-      _websocket_notification_listener_instances[id] = nullptr;
-    }
+  void WebSocket::registerSub(const std::string& channel, const std::string& room_id, const std::string& filters, bool subscribe_to_self, NotificationListener* listener) {
+    _websocket_notification_listener_instances[channel] = listener;
+    kuzzle_websocket_register_sub(this->_web_socket, const_cast<char*>(channel.c_str()), const_cast<char*>(room_id.c_str()), const_cast<char*>(filters.c_str()), subscribe_to_self, trigger_websocket_notification_listener);
+  }
 
-    void WebSocket::cancelSubs() {
-      kuzzle_websocket_cancel_subs(this->_web_socket);
-    }
+  void WebSocket::unregisterSub(const std::string& id) {
+    kuzzle_websocket_unregister_sub(this->_web_socket, const_cast<char*>(id.c_str()));
+    _websocket_notification_listener_instances[id] = nullptr;
+  }
 
-    void WebSocket::startQueuing() {
-      kuzzle_websocket_start_queuing(this->_web_socket);
-    }
+  void WebSocket::cancelSubs() {
+    kuzzle_websocket_cancel_subs(this->_web_socket);
+  }
 
-    void WebSocket::stopQueuing() {
-      kuzzle_websocket_stop_queuing(this->_web_socket);
-    }
-    void WebSocket::playQueue() {
-      kuzzle_websocket_play_queue(this->_web_socket);
-    }
+  void WebSocket::startQueuing() {
+    kuzzle_websocket_start_queuing(this->_web_socket);
+  }
 
-    void WebSocket::clearQueue() {
-      kuzzle_websocket_clear_queue(this->_web_socket);
-    }
+  void WebSocket::stopQueuing() {
+    kuzzle_websocket_stop_queuing(this->_web_socket);
+  }
+  void WebSocket::playQueue() {
+    kuzzle_websocket_play_queue(this->_web_socket);
+  }
 
-    bool WebSocket::isAutoReconnect() {
-      return kuzzle_websocket_is_auto_reconnect(this->_web_socket);
-    }
+  void WebSocket::clearQueue() {
+    kuzzle_websocket_clear_queue(this->_web_socket);
+  }
 
-    bool WebSocket::isAutoResubscribe() {
-      return kuzzle_websocket_is_auto_resubscribe(this->_web_socket);
-    }
+  bool WebSocket::isAutoReconnect() {
+    return kuzzle_websocket_is_auto_reconnect(this->_web_socket);
+  }
 
-    std::string WebSocket::getHost() {
-      return std::string(kuzzle_websocket_get_host(this->_web_socket));
-    }
+  bool WebSocket::isAutoResubscribe() {
+    return kuzzle_websocket_is_auto_resubscribe(this->_web_socket);
+  }
 
-    unsigned int WebSocket::getPort() {
-      return kuzzle_websocket_get_port(this->_web_socket);
-    }
+  std::string WebSocket::getHost() {
+    return std::string(kuzzle_websocket_get_host(this->_web_socket));
+  }
 
-    unsigned long long WebSocket::getReconnectionDelay() {
-      return kuzzle_websocket_get_reconnection_delay(this->_web_socket);
-    }
+  unsigned int WebSocket::getPort() {
+    return kuzzle_websocket_get_port(this->_web_socket);
+  }
 
-    bool WebSocket::isSslConnection() {
-      return kuzzle_websocket_is_ssl_connection(this->_web_socket);
-    }
+  unsigned long long WebSocket::getReconnectionDelay() {
+    return kuzzle_websocket_get_reconnection_delay(this->_web_socket);
+  }
+
+  bool WebSocket::isSslConnection() {
+    return kuzzle_websocket_is_ssl_connection(this->_web_socket);
+  }
 }

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -9,20 +9,16 @@ namespace kuzzleio {
 
   void trigger_websocket_event_listener(int event, char* res, void* data) {
     std::list<EventListener*> listeners = static_cast<WebSocket*>(data)->getListeners(event);
-    if (listeners.size()) {
-      for (EventListener*& listener : listeners) {
-        (*listener)(res);
-      }
+    for (EventListener*& listener : listeners) {
+      (*listener)(res);
     }
   }
 
   void trigger_websocket_once(int event, char* res, void* data) {
     std::list<EventListener*> listeners = static_cast<WebSocket*>(data)->getOnceListeners(event);
-    if (listeners.size()) {
-      for (EventListener*& listener : listeners) {
-        (*listener)(res);
-        static_cast<WebSocket*>(data)->getOnceListeners(event).remove(listener);
-      }
+    for (EventListener*& listener : listeners) {
+      (*listener)(res);
+      static_cast<WebSocket*>(data)->getOnceListeners(event).remove(listener);
     }
   }
 


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-c/pull/46 :warning: 

# Description

This is a stabilization PR, aiming to fix some of the memory issues we have with this SDK:

* The static Kuzzle exception throwing method has been changed: it should not deallocate the memory of the structure provided to it. It now only throws the appropriate exception.
* A new `KUZZLE_API` macro has been added: it DRYifies and standardizes the way the Kuzzle API is requested, and how errors are handled. The main purpose of that macro is to correctly free the C result struct before throwing an exception
* All controller actions now use the new KUZZLE_API macro
* Fix some controller actions using `delete` to free the C result struct, instead of the corresponding C destructor

Note: there are other obvious memleaks remaining. I will address those in other, dedicated PRs, to make this stabilization pass easier to review.

# Other changes

* As per the changes made in the C SDK: the `user_rights_result` struct does not contain a NULL-terminated `result` pointer anymore, but a `rights` pointer, with its size stored in the `rights_length` property
* Fix non-standard indentation in a few files 