### PR TITLE
Make connect() and close() throws instead of returning a string

### DIFF
--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -7,7 +7,7 @@
 #include "internal/protocol.h"
 
 namespace kuzzleio {
-
+  
   class Protocol {
     public:
       protocol *_protocol;
@@ -20,9 +20,9 @@ namespace kuzzleio {
     virtual void removeAllListeners(Event) = 0;
     virtual void once(Event, EventListener*) = 0;
     virtual int listenerCount(Event) = 0;
-    virtual char* connect() = 0;
+    virtual void connect() = 0;
     virtual kuzzle_response* send(const std::string&, query_options *, const std::string&) = 0;
-    virtual std::string close() = 0;
+    virtual void close() = 0;
     virtual int getState() = 0;
     virtual void emitEvent(Event) = 0;
     virtual void registerSub(const std::string&, const std::string&, const std::string&, bool, NotificationListener*) = 0;

--- a/include/websocket.hpp
+++ b/include/websocket.hpp
@@ -25,9 +25,9 @@ namespace kuzzleio {
     virtual void removeAllListeners(Event);
     virtual void once(Event, EventListener*);
     virtual int listenerCount(Event);
-    virtual char* connect();
+    virtual void connect();
     virtual kuzzle_response* send(const std::string&, query_options *, const std::string&);
-    virtual std::string close();
+    virtual void close();
     virtual int getState();
     virtual void emitEvent(Event);
     virtual void registerSub(const std::string&, const std::string&, const std::string&, bool, NotificationListener*);

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -59,7 +59,12 @@ namespace kuzzleio {
   }
 
   char* bridge_cpp_connect(void* data) {
-    return static_cast<Protocol*>(data)->connect();
+    try {
+      static_cast<Protocol*>(data)->connect();
+    } catch (KuzzleException& e) {
+      return const_cast<char*>(e.what());
+    }
+    return nullptr;
   }
 
   int bridge_cpp_get_state(void* data) {
@@ -75,7 +80,12 @@ namespace kuzzleio {
   }
 
   const char* bridge_cpp_close(void* data) {
-    return static_cast<Protocol*>(data)->close().c_str();
+    try {
+      static_cast<Protocol*>(data)->close();
+    } catch (KuzzleException& e) {
+      return e.what();
+    }
+    return nullptr;
   }
 
   void bridge_cpp_register_sub(const char* channel, const char* room_id, const char* filters, bool subscribe_to_self, kuzzle_notification_listener* listener, void* data) {

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -69,8 +69,13 @@ namespace kuzzleio {
       return kuzzle_websocket_listener_count(this->_web_socket, event);
     }
 
-    char* WebSocket::connect() {
-      return kuzzle_websocket_connect(this->_web_socket);
+    void WebSocket::connect() {
+      char* err = kuzzle_websocket_connect(this->_web_socket);
+      if (err != NULL) {
+        const std::string cppError = err;
+        free(err);
+        throw InternalException(cppError);
+      }
     }
 
     kuzzle_response* WebSocket::send(const std::string& query, query_options *options, const std::string& request_id) {
@@ -78,12 +83,14 @@ namespace kuzzleio {
       return res;
     }
 
-    std::string WebSocket::close() {
-      const char* res = kuzzle_websocket_close(this->_web_socket);
-      if (res) {
-        return std::string(kuzzle_websocket_close(this->_web_socket));
+    void WebSocket::close() {
+      char* err = kuzzle_websocket_close(this->_web_socket);
+
+      if (err != NULL) {
+        const std::string cppError = err;
+        free(err);
+        throw InternalException(cppError);
       }
-      return "";
     }
 
     int WebSocket::getState() {


### PR DESCRIPTION
## What does this PR do ?

Change the behavior of Protocol::connect() and Protocol::close() to make them throws in case of error.
