### PR TITLE
SWIG compatibility update

### DIFF
--- a/include/internal/auth.hpp
+++ b/include/internal/auth.hpp
@@ -41,7 +41,7 @@ namespace kuzzleio {
       void deleteMyCredentials(const std::string& strategy, query_options *options=nullptr);
       User getCurrentUser();
       std::string getMyCredentials(const std::string& strategy, query_options *options=nullptr);
-      std::vector<std::unique_ptr<UserRight>> getMyRights(query_options *options=nullptr);
+      std::vector<std::shared_ptr<UserRight>> getMyRights(query_options *options=nullptr);
       std::vector<std::string> getStrategies(query_options *options=nullptr);
       std::string login(const std::string& strategy, const std::string& credentials, int expiresIn);
       std::string login(const std::string& strategy, const std::string& credentials);

--- a/include/internal/user_right.hpp
+++ b/include/internal/user_right.hpp
@@ -21,13 +21,13 @@
 namespace kuzzleio {
   class UserRight {
     private:
+      std::string _controller;
       std::string _action;
       std::string _index;
       std::string _collection;
       std::string _value;
 
     public:
-      std::string _controller;
       std::string const& controller() const;
       std::string const& action() const;
       std::string const& index() const;

--- a/include/internal/user_right.hpp
+++ b/include/internal/user_right.hpp
@@ -28,11 +28,11 @@ namespace kuzzleio {
       std::string _value;
 
     public:
-      std::string const& controller() const;
-      std::string const& action() const;
-      std::string const& index() const;
-      std::string const& collection() const;
-      std::string const& value() const;
+      const std::string& controller() const;
+      const std::string& action() const;
+      const std::string& index() const;
+      const std::string& collection() const;
+      const std::string& value() const;
 
       void controller(std::string const&);
       void action(std::string const&);

--- a/include/internal/user_right.hpp
+++ b/include/internal/user_right.hpp
@@ -21,13 +21,13 @@
 namespace kuzzleio {
   class UserRight {
     private:
-    std::string _action;
-    std::string _index;
-    std::string _collection;
-    std::string _value;
+      std::string _action;
+      std::string _index;
+      std::string _collection;
+      std::string _value;
 
     public:
-    std::string _controller;
+      std::string _controller;
       std::string const& controller() const;
       std::string const& action() const;
       std::string const& index() const;

--- a/include/internal/user_right.hpp
+++ b/include/internal/user_right.hpp
@@ -20,19 +20,33 @@
 
 namespace kuzzleio {
   class UserRight {
-    public:
-      const std::string controller;
-      const std::string action;
-      const std::string index;
-      const std::string collection;
-      const std::string value;
+    private:
+    std::string _action;
+    std::string _index;
+    std::string _collection;
+    std::string _value;
 
+    public:
+    std::string _controller;
+      std::string const& controller() const;
+      std::string const& action() const;
+      std::string const& index() const;
+      std::string const& collection() const;
+      std::string const& value() const;
+
+      void controller(std::string const&);
+      void action(std::string const&);
+      void index(std::string const&);
+      void collection(std::string const&);
+      void value(std::string const&);
+
+      UserRight() = default;
       UserRight(const user_right* r) :
-        controller(r->controller),
-        action(r->action),
-        index(r->index),
-        collection(r->collection),
-        value(r->value)
+        _controller(r->controller),
+        _action(r->action),
+        _index(r->index),
+        _collection(r->collection),
+        _value(r->value)
         {};
   };
 }

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -75,14 +75,14 @@ namespace kuzzleio {
     return ret;
   }
 
-  std::vector<std::unique_ptr<UserRight>> Auth::getMyRights(query_options* options) {
+  std::vector<std::shared_ptr<UserRight>> Auth::getMyRights(query_options* options) {
     KUZZLE_API(user_rights_result, r, kuzzle_get_my_rights(_auth, options))
 
-    std::vector<std::unique_ptr<UserRight>> user_rights;
+    std::vector<std::shared_ptr<UserRight>> user_rights;
     user_rights.reserve(r->rights_length);
 
     for (size_t i = 0; i < r->rights_length; ++i) {
-      std::unique_ptr<UserRight> right(new UserRight(r->rights[i]));
+      std::shared_ptr<UserRight> right(new UserRight(r->rights[i]));
       user_rights.push_back(std::move(right));
     }
 

--- a/src/user_right.cpp
+++ b/src/user_right.cpp
@@ -1,0 +1,58 @@
+// Copyright 2015-2018 Kuzzle
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kuzzle.hpp"
+#include "internal/user_right.hpp"
+
+namespace kuzzleio {
+  std::string const& UserRight::controller() const {
+    return _controller;
+  }
+
+  std::string const& UserRight::action() const {
+    return _action;
+  }
+
+  std::string const& UserRight::index() const {
+    return _index;
+  }
+
+  std::string const& UserRight::collection() const {
+    return _collection;
+  }
+
+  std::string const& UserRight::value() const {
+    return _value;
+  }
+
+  void UserRight::controller(std::string const& value) {
+    this->_controller = value;
+  }
+
+  void UserRight::action(std::string const& value) {
+    this->_action = value;
+  }
+
+  void UserRight::collection(std::string const& value) {
+    this->_collection = value;
+  }
+
+  void UserRight::index(std::string const& value) {
+    this->_index = value;
+  }
+
+  void UserRight::value(std::string const& value) {
+    this->_value = value;
+  }
+}

--- a/test/features/step_definitions/steps.hpp
+++ b/test/features/step_definitions/steps.hpp
@@ -34,7 +34,7 @@ struct KuzzleCtx {
   string jwt;
   string document_id;
   SearchResult *documents;
-  std::vector<std::unique_ptr<UserRight>> user_rights;
+  std::vector<std::shared_ptr<UserRight>> user_rights;
 
   string room_id;
 


### PR DESCRIPTION
# Description

Compatibility update to make this SDK usable by SWIG:

- the new `UserRight` class needs a default constructor
- the `auth:getMyRights` method no longer return a vector of unique_ptr pointers, as this triggers [a SWIG bug](https://github.com/swig/swig/issues/558), with no known workaround. Instead, shared_ptr pointers are returned