### PR TITLE
Controllers allocate their own memory

### DIFF
--- a/include/internal/auth.hpp
+++ b/include/internal/auth.hpp
@@ -26,14 +26,11 @@ namespace kuzzleio {
   class Kuzzle;
 
   class Auth {
-    auth *_auth;
-    Auth();
-
+    private:
+      auth *_auth;
+      kuzzle *_kuzzle;
     public:
-      Kuzzle *_kuzzle;
-
-      Auth(Kuzzle *kuzzle);
-      Auth(Kuzzle *kuzzle, auth *auth);
+      Auth(kuzzle *kuzzle);
       virtual ~Auth();
       token_validity* checkToken(const std::string& token);
       std::string createMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options=nullptr);

--- a/include/internal/collection.hpp
+++ b/include/internal/collection.hpp
@@ -27,12 +27,11 @@ namespace kuzzleio {
     class SearchResult;
 
     class Collection {
-        collection* _collection;
-        Collection();
+        private:
+            collection* _collection;
 
         public:
-            Collection(Kuzzle* kuzzle);
-            Collection(Kuzzle* kuzzle, collection *collection);
+            Collection(kuzzle* kuzzle);
             virtual ~Collection();
             void create(const std::string& index, const std::string& collection, const std::string* body=nullptr, query_options *options=nullptr);
             bool exists(const std::string& index, const std::string& collection, query_options *options=nullptr);

--- a/include/internal/document.hpp
+++ b/include/internal/document.hpp
@@ -22,12 +22,11 @@
 namespace kuzzleio {
 
     class Document {
-        document* _document;
-        Document();
+        private:
+            document* _document;
 
         public:
-            Document(Kuzzle* kuzzle);
-            Document(Kuzzle* kuzzle, document *document);
+            Document(kuzzle* kuzzle);
             virtual ~Document();
             int count(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
             int count(const std::string& index, const std::string& collection, query_options *options=nullptr);

--- a/include/internal/index.hpp
+++ b/include/internal/index.hpp
@@ -14,7 +14,7 @@
 
 #ifndef _KUZZLE_INDEX_HPP
 #define _KUZZLE_INDEX_HPP
-#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
 #include "exceptions.hpp"
 #include "core.hpp"
@@ -22,12 +22,11 @@
 namespace kuzzleio {
   class Kuzzle;
   class Index {
-    kuzzle_index *_index;
-    Index();
+    private:
+      kuzzle_index *_index;
 
     public:
-      Index(Kuzzle* kuzzle);
-      Index(Kuzzle* kuzzle, kuzzle_index *index);
+      Index(kuzzle* kuzzle);
       virtual ~Index();
       void create(const std::string& index, query_options *options=nullptr);
       void delete_(const std::string& index, query_options *options=nullptr);

--- a/include/internal/realtime.hpp
+++ b/include/internal/realtime.hpp
@@ -13,13 +13,12 @@ namespace kuzzleio {
   class Kuzzle;
 
   class Realtime {
-    realtime *_realtime;
-    std::map<std::string, NotificationListener*> _listener_instances;
-    Realtime();
+    private:
+      realtime *_realtime;
+      std::map<std::string, NotificationListener*> _listener_instances;
 
     public:
-      Realtime(Kuzzle* kuzzle);
-      Realtime(Kuzzle* kuzzle, realtime* realtime);
+      Realtime(kuzzle* kuzzle);
       virtual ~Realtime();
       int count(const std::string& roomId, query_options *options=nullptr);
       void publish(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);

--- a/include/internal/server.hpp
+++ b/include/internal/server.hpp
@@ -20,12 +20,11 @@
 
 namespace kuzzleio {
   class Server {
-    server *_server;
-    Server();
+    private:
+      server *_server;
 
     public:
-      Server(Kuzzle* kuzzle);
-      Server(Kuzzle *kuzzle, server *server);
+      Server(kuzzle* kuzzle);
       virtual ~Server();
       bool adminExists(query_options *options=nullptr);
       std::string getAllStats(query_options* options=nullptr);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -16,19 +16,17 @@
 #include "internal/collection.hpp"
 
 namespace kuzzleio {
-  Collection::Collection(Kuzzle* kuzzle) {
-    _collection = new collection();
-    kuzzle_new_collection(_collection, kuzzle->_kuzzle);
-  }
-
-  Collection::Collection(Kuzzle* kuzzle, collection *collection) {
-    _collection = collection;
-    kuzzle_new_collection(collection, kuzzle->_kuzzle);
+  Collection::Collection(kuzzle* kuzzle) {
+    _collection = kuzzle_get_collection_controller(kuzzle);
+    kuzzle_new_collection(_collection, kuzzle);
   }
 
   Collection::~Collection() {
     unregisterCollection(_collection);
-    delete(_collection);
+
+    // do not use "delete":
+    // _collection is allocating in the cgo world, using calloc
+    free(_collection);
   }
 
   void Collection::create(const std::string& index, const std::string& collection, const std::string* body, query_options *options) {

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -17,19 +17,17 @@
 #include "internal/search_result.hpp"
 
 namespace kuzzleio {
-  Document::Document(Kuzzle* kuzzle) {
-    _document = new document();
-    kuzzle_new_document(_document, kuzzle->_kuzzle);
-  }
-
-  Document::Document(Kuzzle* kuzzle, document *document) {
-    _document = document;
-    kuzzle_new_document(_document, kuzzle->_kuzzle);
+  Document::Document(kuzzle* kuzzle) {
+    _document = kuzzle_get_document_controller(kuzzle);
+    kuzzle_new_document(_document, kuzzle);
   }
 
   Document::~Document() {
     unregisterDocument(_document);
-    delete(_document);
+
+    // do not use "delete":
+    // _document is allocating in the cgo world, using calloc
+    free(_document);
   }
 
   int Document::count(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -16,19 +16,17 @@
 #include "internal/index.hpp"
 
 namespace kuzzleio {
-  Index::Index(Kuzzle* kuzzle) {
-    _index = new kuzzle_index();
-    kuzzle_new_index(_index, kuzzle->_kuzzle);
-  }
-
-  Index::Index(Kuzzle* kuzzle, kuzzle_index *index) {
-    _index = index;
-    kuzzle_new_index(index, kuzzle->_kuzzle);
+  Index::Index(kuzzle* kuzzle) {
+    _index = kuzzle_get_index_controller(kuzzle);
+    kuzzle_new_index(_index, kuzzle);
   }
 
   Index::~Index() {
     unregisterIndex(_index);
-    delete(_index);
+
+    // do not use "delete":
+    // _index is allocating in the cgo world, using calloc
+    free(_index);
   }
 
   void Index::create(const std::string& index, query_options *options) {

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -168,12 +168,12 @@ namespace kuzzleio {
 
     kuzzle_new_kuzzle(this->_kuzzle, this->_protocol, opts);
 
-    this->document = new Document(this, kuzzle_get_document_controller(_kuzzle));
-    this->auth = new Auth(this, kuzzle_get_auth_controller(_kuzzle));
-    this->index = new Index(this, kuzzle_get_index_controller(_kuzzle));
-    this->server = new Server(this, kuzzle_get_server_controller(_kuzzle));
-    this->collection = new Collection(this, kuzzle_get_collection_controller(_kuzzle));
-    this->realtime = new Realtime(this, kuzzle_get_realtime_controller(_kuzzle));
+    this->document = new Document(_kuzzle);
+    this->auth = new Auth(_kuzzle);
+    this->index = new Index(_kuzzle);
+    this->server = new Server(_kuzzle);
+    this->collection = new Collection(_kuzzle);
+    this->realtime = new Realtime(_kuzzle);
   }
 
   Kuzzle::~Kuzzle() {

--- a/src/realtime.cpp
+++ b/src/realtime.cpp
@@ -16,19 +16,17 @@
 #include "internal/realtime.hpp"
 
 namespace kuzzleio {
-  Realtime::Realtime(Kuzzle *kuzzle) {
-    _realtime = new realtime();
-    kuzzle_new_realtime(_realtime, kuzzle->_kuzzle);
-  }
-
-  Realtime::Realtime(Kuzzle *kuzzle, realtime *realtime) {
-    _realtime = realtime;
-    kuzzle_new_realtime(_realtime, kuzzle->_kuzzle);
+  Realtime::Realtime(kuzzle *kuzzle) {
+    _realtime = kuzzle_get_realtime_controller(kuzzle);
+    kuzzle_new_realtime(_realtime, kuzzle);
   }
 
   Realtime::~Realtime() {
     unregisterRealtime(_realtime);
-    delete(_realtime);
+
+    // do not use "delete":
+    // _realtime is allocating in the cgo world, using calloc
+    free(_realtime);
   }
 
   int Realtime::count(const std::string& roomId, query_options *options) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -16,19 +16,17 @@
 #include "internal/server.hpp"
 
 namespace kuzzleio {
-  Server::Server(Kuzzle* kuzzle) {
-    _server = new server();
-    kuzzle_new_server(_server, kuzzle->_kuzzle);
-  }
-
-  Server::Server(Kuzzle* kuzzle, server *server) {
-    _server = server;
-    kuzzle_new_server(_server, kuzzle->_kuzzle);
+  Server::Server(kuzzle* kuzzle) {
+    _server = kuzzle_get_server_controller(kuzzle);
+    kuzzle_new_server(_server, kuzzle);
   }
 
   Server::~Server() {
     unregisterServer(_server);
-    delete(_server);
+
+    // do not use "delete":
+    // _server is allocating in the cgo world, using calloc
+    free(_server);
   }
 
   bool Server::adminExists(query_options *options) {


### PR DESCRIPTION
# Description

Instead of getting the Go controllers from the Kuzzle object, and pass it to controllers while instantiating them, this PR makes the C++ controllers get their Go counterpart themselves.

This has the following benefits:

* regroup the memory allocation/deallocation in the same place
* make it easier to track with what a pointer has been allocated, and use the correct deallocator method (i.e. fix valgrind reports of pointers being deallocated with "delete" instead of "free")
* get rid of unused constructors
* simplify the C++ controllers generation process
