### PR TITLE
KZL-972 - Use multi signatures instead of default arguments

### DIFF
--- a/include/internal/auth.hpp
+++ b/include/internal/auth.hpp
@@ -29,24 +29,48 @@ namespace kuzzleio {
     private:
       auth *_auth;
       kuzzle *_kuzzle;
+
     public:
       Auth(kuzzle *kuzzle);
       virtual ~Auth();
+
       token_validity* checkToken(const std::string& token);
-      std::string createMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options=nullptr);
-      bool credentialsExist(const std::string& strategy, query_options *options=nullptr);
-      void deleteMyCredentials(const std::string& strategy, query_options *options=nullptr);
+
+      std::string createMyCredentials(const std::string& strategy, const std::string& credentials);
+      std::string createMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options);
+
+      bool credentialsExist(const std::string& strategy);
+      bool credentialsExist(const std::string& strategy, const query_options& options);
+
+      void deleteMyCredentials(const std::string& strategy);
+      void deleteMyCredentials(const std::string& strategy, const query_options& options);
+
       User getCurrentUser();
-      std::string getMyCredentials(const std::string& strategy, query_options *options=nullptr);
-      std::vector<std::shared_ptr<UserRight>> getMyRights(query_options *options=nullptr);
-      std::vector<std::string> getStrategies(query_options *options=nullptr);
-      std::string login(const std::string& strategy, const std::string& credentials, int expiresIn);
+
+      std::string getMyCredentials(const std::string& strategy);
+      std::string getMyCredentials(const std::string& strategy, const query_options& options);
+
+      std::vector<std::shared_ptr<UserRight>> getMyRights();
+      std::vector<std::shared_ptr<UserRight>> getMyRights(const query_options& options);
+
+      std::vector<std::string> getStrategies();
+      std::vector<std::string> getStrategies(const query_options& options);
+
       std::string login(const std::string& strategy, const std::string& credentials);
+      std::string login(const std::string& strategy, const std::string& credentials, int expiresIn);
+
       void logout() noexcept;
+
       void setJwt(const std::string& jwt) noexcept;
-      std::string updateMyCredentials(const std::string& strategy, const std::string& credentials, query_options *options=nullptr);
-      User updateSelf(const std::string& content, query_options* options=nullptr);
-      bool validateMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options=nullptr);
+
+      std::string updateMyCredentials(const std::string& strategy, const std::string& credentials);
+      std::string updateMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options);
+
+      User updateSelf(const std::string& content);
+      User updateSelf(const std::string& content, const query_options& options);
+
+      bool validateMyCredentials(const std::string& strategy, const std::string& credentials);
+      bool validateMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options);
   };
 }
 

--- a/include/internal/collection.hpp
+++ b/include/internal/collection.hpp
@@ -35,22 +35,40 @@ namespace kuzzleio {
             Collection(kuzzle* kuzzle);
             virtual ~Collection();
 
-            void create(const std::string& index, const std::string& collection, query_options *options=nullptr);
-            void create(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            void truncate(const std::string& index, const std::string& collection, query_options *options=nullptr);
-            void updateMapping(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            void deleteSpecifications(const std::string& index, const std::string& collection, query_options *options=nullptr);
+            void create(const std::string& index, const std::string& collection);
+            void create(const std::string& index, const std::string& collection, const std::string& mapping);
+            void create(const std::string& index, const std::string& collection, const query_options& options);
+            void create(const std::string& index, const std::string& collection, const std::string& mapping, const query_options& options);
 
-            bool exists(const std::string& index, const std::string& collection, query_options *options=nullptr);
+            void truncate(const std::string& index, const std::string& collection);
+            void truncate(const std::string& index, const std::string& collection, const query_options& options);
 
-            std::string list(const std::string& index, query_options *options=nullptr);
-            std::string getMapping(const std::string& index, const std::string& collection, query_options *options=nullptr);
-            std::string getSpecifications(const std::string& index, const std::string& collection, query_options *options=nullptr);
-            std::string updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options=nullptr);
+            void updateMapping(const std::string& index, const std::string& collection, const std::string& mapping);
+            void updateMapping(const std::string& index, const std::string& collection, const std::string& mapping, const query_options& options);
 
-            SearchResult* searchSpecifications(const std::string& body, query_options *options=nullptr);
+            void deleteSpecifications(const std::string& index, const std::string& collection);
+            void deleteSpecifications(const std::string& index, const std::string& collection, const query_options& options);
 
-            validation_response* validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options=nullptr);
+            bool exists(const std::string& index, const std::string& collection);
+            bool exists(const std::string& index, const std::string& collection, const query_options& options);
+
+            std::string list(const std::string& index);
+            std::string list(const std::string& index, const query_options& options);
+
+            std::string getMapping(const std::string& index, const std::string& collection);
+            std::string getMapping(const std::string& index, const std::string& collection, const query_options& options);
+
+            std::string getSpecifications(const std::string& index, const std::string& collection);
+            std::string getSpecifications(const std::string& index, const std::string& collection, const query_options& options);
+
+            std::string updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications);
+            std::string updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, const query_options& options);
+
+            SearchResult* searchSpecifications(const std::string& query);
+            SearchResult* searchSpecifications(const std::string& query, const query_options& options);
+
+            validation_response* validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications);
+            validation_response* validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, const query_options& options);
     };
 }
 

--- a/include/internal/document.hpp
+++ b/include/internal/document.hpp
@@ -28,24 +28,59 @@ namespace kuzzleio {
         public:
             Document(kuzzle* kuzzle);
             virtual ~Document();
-            int count(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            int count(const std::string& index, const std::string& collection, query_options *options=nullptr);
-            bool exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options=nullptr);
-            std::string create(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);
-            std::string createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);
-            std::string delete_(const std::string& index, const std::string& collection, const std::string& id, query_options *options=nullptr);
-            std::vector<std::string> deleteByQuery(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            std::string get(const std::string& index, const std::string& collection, const std::string& id, query_options *options=nullptr);
-            std::string replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);
-            std::string update(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options=nullptr);
-            bool validate(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            SearchResult* search(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            std::string mCreate(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            std::string mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            std::vector<std::string> mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options=nullptr);
-            std::string mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options=nullptr);
-            std::string mReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-            std::string mUpdate(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
+
+            int count(const std::string& index, const std::string& collection);
+            int count(const std::string& index, const std::string& collection, const query_options& options);
+            int count(const std::string& index, const std::string& collection, const std::string& query);
+            int count(const std::string& index, const std::string& collection, const std::string& query, const query_options& options);
+
+            bool exists(const std::string& index, const std::string& collection, const std::string& id);
+            bool exists(const std::string& index, const std::string& collection, const std::string& id, const query_options& options);
+
+            std::string create(const std::string& index, const std::string& collection, const std::string& id, const std::string& document);
+            std::string create(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options);
+
+            std::string createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document);
+            std::string createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options);
+
+            std::string delete_(const std::string& index, const std::string& collection, const std::string& id);
+            std::string delete_(const std::string& index, const std::string& collection, const std::string& id, const query_options& options);
+
+            std::vector<std::string> deleteByQuery(const std::string& index, const std::string& collection, const std::string& query);
+            std::vector<std::string> deleteByQuery(const std::string& index, const std::string& collection, const std::string& query, const query_options& options);
+
+            std::string get(const std::string& index, const std::string& collection, const std::string& id);
+            std::string get(const std::string& index, const std::string& collection, const std::string& id, const query_options& options);
+
+            std::string replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document);
+            std::string replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options);
+
+            std::string update(const std::string& index, const std::string& collection, const std::string& id, const std::string& document);
+            std::string update(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options);
+
+            bool validate(const std::string& index, const std::string& collection, const std::string& document);
+            bool validate(const std::string& index, const std::string& collection, const std::string& document, const query_options& options);
+
+            SearchResult* search(const std::string& index, const std::string& collection, const std::string& query);
+            SearchResult* search(const std::string& index, const std::string& collection, const std::string& query, const query_options& options);
+
+            std::string mCreate(const std::string& index, const std::string& collection, const std::string& documents);
+            std::string mCreate(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options);
+
+            std::string mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& documents);
+            std::string mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options);
+
+            std::vector<std::string> mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids);
+            std::vector<std::string> mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options);
+
+            std::string mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids);
+            std::string mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options);
+
+            std::string mReplace(const std::string& index, const std::string& collection, const std::string& documents);
+            std::string mReplace(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options);
+
+            std::string mUpdate(const std::string& index, const std::string& collection, const std::string& documents);
+            std::string mUpdate(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options);
     };
 }
 

--- a/include/internal/index.hpp
+++ b/include/internal/index.hpp
@@ -28,15 +28,33 @@ namespace kuzzleio {
     public:
       Index(kuzzle* kuzzle);
       virtual ~Index();
-      void create(const std::string& index, query_options *options=nullptr);
-      void delete_(const std::string& index, query_options *options=nullptr);
-      std::vector<std::string> mDelete(const std::vector<std::string>& indexes, query_options *options=nullptr);
-      bool exists(const std::string& index, query_options *options=nullptr);
-      void refresh(const std::string& index, query_options *options=nullptr);
-      void refreshInternal(query_options *options=nullptr);
-      void setAutoRefresh(const std::string& index, bool autoRefresh, query_options *options=nullptr);
-      bool getAutoRefresh(const std::string& index, query_options *options=nullptr);
-      std::vector<std::string> list(query_options *options=nullptr);
+
+      void create(const std::string& index);
+      void create(const std::string& index, const query_options& options);
+
+      void delete_(const std::string& index);
+      void delete_(const std::string& index, const query_options& options);
+
+      std::vector<std::string> mDelete(const std::vector<std::string>& indexes);
+      std::vector<std::string> mDelete(const std::vector<std::string>& indexes, const query_options& options);
+
+      bool exists(const std::string& index);
+      bool exists(const std::string& index, const query_options& options);
+
+      void refresh(const std::string& index);
+      void refresh(const std::string& index, const query_options& options);
+
+      void refreshInternal();
+      void refreshInternal(const query_options& options);
+
+      void setAutoRefresh(const std::string& index, bool auto_refresh);
+      void setAutoRefresh(const std::string& index, bool auto_refresh, const query_options& options);
+
+      bool getAutoRefresh(const std::string& index);
+      bool getAutoRefresh(const std::string& index, const query_options& options);
+
+      std::vector<std::string> list();
+      std::vector<std::string> list(const query_options& options);
   };
 }
 

--- a/include/internal/realtime.hpp
+++ b/include/internal/realtime.hpp
@@ -20,12 +20,21 @@ namespace kuzzleio {
     public:
       Realtime(kuzzle* kuzzle);
       virtual ~Realtime();
-      int count(const std::string& roomId, query_options *options=nullptr);
-      void publish(const std::string& index, const std::string& collection, const std::string& body, query_options *options=nullptr);
-      std::string subscribe(const std::string& index, const std::string& collection, const std::string& body, NotificationListener* cb, room_options* options=nullptr);
-      void unsubscribe(const std::string& roomId, query_options *options=nullptr);
 
-      NotificationListener* getListener(const std::string& roomId);
+      int count(const std::string& room_id);
+      int count(const std::string& room_id, const query_options& options);
+
+      void publish(const std::string& index, const std::string& collection, const std::string& message);
+      void publish(const std::string& index, const std::string& collection, const std::string& message, const query_options& options);
+
+      std::string subscribe(const std::string& index, const std::string& collection, const std::string& filters, NotificationListener* listener);
+      std::string subscribe(const std::string& index, const std::string& collection, const std::string& filters, NotificationListener* listener, const room_options& options);
+
+      void unsubscribe(const std::string& room_id);
+      void unsubscribe(const std::string& room_id, const query_options& options);
+
+      // Internal usage only
+      NotificationListener* getListener(const std::string& room_id);
   };
 }
 

--- a/include/internal/search_result.hpp
+++ b/include/internal/search_result.hpp
@@ -21,7 +21,7 @@ namespace kuzzleio {
 
     class SearchResult {
         protected:
-            search_result* _sr;
+            const search_result* _sr;
 
         public:
             std::string aggregations;
@@ -30,16 +30,16 @@ namespace kuzzleio {
             unsigned fetched;
             std::string scroll_id;
 
-            SearchResult(search_result* sr);
+            SearchResult(const search_result* sr);
             virtual ~SearchResult();
-            SearchResult* next();
+            SearchResult* next() const;
     };
 
     class SpecificationSearchResult : public SearchResult {
         public:
-            SpecificationSearchResult(search_result* sr);
+            SpecificationSearchResult(const search_result* sr);
             virtual ~SpecificationSearchResult();
-            SpecificationSearchResult* next();
+            SpecificationSearchResult* next() const;
     };
 
 }

--- a/include/internal/server.hpp
+++ b/include/internal/server.hpp
@@ -26,13 +26,27 @@ namespace kuzzleio {
     public:
       Server(kuzzle* kuzzle);
       virtual ~Server();
-      bool adminExists(query_options *options=nullptr);
-      std::string getAllStats(query_options* options=nullptr);
-      std::string getStats(time_t start, time_t end, query_options* options=nullptr);
-      std::string getLastStats(query_options* options=nullptr);
-      std::string getConfig(query_options* options=nullptr);
-      std::string info(query_options* options=nullptr);
-      long long now(query_options* options=nullptr);
+
+      bool adminExists();
+      bool adminExists(const query_options& options);
+
+      std::string getAllStats();
+      std::string getAllStats(const query_options& options);
+
+      std::string getStats(time_t start, time_t end);
+      std::string getStats(time_t start, time_t end, const query_options& options);
+
+      std::string getLastStats();
+      std::string getLastStats(const query_options& options);
+
+      std::string getConfig();
+      std::string getConfig(const query_options& options);
+
+      std::string info();
+      std::string info(const query_options& options);
+
+      long long now();
+      long long now(const query_options& options);
   };
 }
 

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -90,31 +90,39 @@ namespace kuzzleio {
       Document *document;
       Realtime *realtime;
 
-      Kuzzle(Protocol* protocol, options *options=nullptr);
+
+      Kuzzle(Protocol* protocol);
+      Kuzzle(Protocol* protocol, const options& options);
       virtual ~Kuzzle();
 
       void connect();
-
-      std::string getJwt() noexcept;
       void disconnect() noexcept;
-      kuzzle_response* query(kuzzle_request* query, query_options* options=nullptr);
-      Kuzzle* playQueue() noexcept;
-      Kuzzle* setAutoReplay(bool autoReplay) noexcept;
+      void emitEvent(Event event, const std::string& payload) noexcept;
+      kuzzle_response* query(const kuzzle_request& request);
+      kuzzle_response* query(const kuzzle_request& request, const query_options& options);
+
+      // Offline queue
       Kuzzle* startQueuing() noexcept;
       Kuzzle* stopQueuing() noexcept;
+      Kuzzle* playQueue() noexcept;
       Kuzzle* flushQueue() noexcept;
-      std::string getVolatile() noexcept;
-      Kuzzle* setVolatile(const std::string& volatiles) noexcept;
-      std::map<int, EventListener*> getListeners() noexcept;
-      void emitEvent(Event event, const std::string& body) noexcept;
-      Protocol* getProtocol() noexcept;
 
+      // Setters
+      Kuzzle* setAutoReplay(bool value) noexcept;
+      Kuzzle* setVolatile(const std::string& volatile_data) noexcept;
+
+      // Getters
+      Protocol* getProtocol() noexcept;
+      std::string getJwt() noexcept;
+      std::string getVolatile() noexcept;
+      std::map<int, EventListener*> getListeners() noexcept;
+
+      // KuzzleEventEmitter implementation
+      virtual int listenerCount(Event event) override;
       virtual KuzzleEventEmitter* addListener(Event event, EventListener* listener) override;
       virtual KuzzleEventEmitter* removeListener(Event event, EventListener* listener) override;
       virtual KuzzleEventEmitter* removeAllListeners(Event event) override;
       virtual KuzzleEventEmitter* once(Event event, EventListener* listener) override;
-      virtual int listenerCount(Event event) override;
-
   };
 }
 

--- a/include/websocket.hpp
+++ b/include/websocket.hpp
@@ -15,7 +15,9 @@ namespace kuzzleio {
       std::map<std::string, NotificationListener*>  _websocket_notification_listener_instances;
     public:
     web_socket* _web_socket;
-    WebSocket(const std::string&, options* query_options=nullptr);
+    WebSocket(const std::string& host);
+    WebSocket(const std::string& host, const options& query_options);
+
     std::list<EventListener*> getListeners(int) noexcept;
     std::list<EventListener*> getOnceListeners(int) noexcept;
     NotificationListener* getNotificationListener(const std::string&) noexcept;

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -34,8 +34,14 @@ namespace kuzzleio {
     return kuzzle_check_token(_auth, const_cast<char*>(token.c_str()));
   }
 
-  std::string Auth::createMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options) {
-    KUZZLE_API(string_result, r, kuzzle_create_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options))
+  std::string Auth::createMyCredentials(const std::string& strategy, const std::string& credentials) {
+    query_options options;
+
+    return this->createMyCredentials(strategy, credentials, options);
+  }
+
+  std::string Auth::createMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_create_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
 
@@ -43,16 +49,28 @@ namespace kuzzleio {
     return ret;
   }
 
-  bool Auth::credentialsExist(const std::string& strategy, query_options *options) {
-    KUZZLE_API(bool_result, r, kuzzle_credentials_exist(_auth, const_cast<char*>(strategy.c_str()), options))
+  bool Auth::credentialsExist(const std::string& strategy) {
+    query_options options;
+
+    return this->credentialsExist(strategy, options);
+  }
+
+  bool Auth::credentialsExist(const std::string& strategy, const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_credentials_exist(_auth, const_cast<char*>(strategy.c_str()), const_cast<query_options*>(&options)))
 
     bool ret = r->result;
     kuzzle_free_bool_result(r);
     return ret;
   }
 
-  void Auth::deleteMyCredentials(const std::string& strategy, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_delete_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options))
+  void Auth::deleteMyCredentials(const std::string& strategy) {
+    query_options options;
+
+    this->deleteMyCredentials(strategy, options);
+  }
+
+  void Auth::deleteMyCredentials(const std::string& strategy, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_delete_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<query_options*>(&options)))
     kuzzle_free_error_result(r);
   }
 
@@ -64,16 +82,29 @@ namespace kuzzleio {
     return u;
   }
 
-  std::string Auth::getMyCredentials(const std::string& strategy, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_get_my_credentials(_auth, const_cast<char*>(strategy.c_str()), options))
+
+  std::string Auth::getMyCredentials(const std::string& strategy) {
+    query_options options;
+
+    return this->getMyCredentials(strategy, options);
+  }
+
+  std::string Auth::getMyCredentials(const std::string& strategy, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_get_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
     return ret;
   }
 
-  std::vector<std::shared_ptr<UserRight>> Auth::getMyRights(query_options* options) {
-    KUZZLE_API(user_rights_result, r, kuzzle_get_my_rights(_auth, options))
+  std::vector<std::shared_ptr<UserRight>> Auth::getMyRights() {
+    query_options options;
+
+    return this->getMyRights(options);
+  }
+
+  std::vector<std::shared_ptr<UserRight>> Auth::getMyRights(const query_options& options) {
+    KUZZLE_API(user_rights_result, r, kuzzle_get_my_rights(_auth, const_cast<query_options*>(&options)))
 
     std::vector<std::shared_ptr<UserRight>> user_rights;
     user_rights.reserve(r->rights_length);
@@ -87,8 +118,14 @@ namespace kuzzleio {
     return user_rights;
   }
 
-  std::vector<std::string> Auth::getStrategies(query_options *options) {
-    KUZZLE_API(string_array_result, r, kuzzle_get_strategies(_auth, options))
+  std::vector<std::string> Auth::getStrategies() {
+    query_options options;
+
+    return this->getStrategies(options);
+  }
+
+  std::vector<std::string> Auth::getStrategies(const query_options& options) {
+    KUZZLE_API(string_array_result, r, kuzzle_get_strategies(_auth, const_cast<query_options*>(&options)))
 
     std::vector<std::string> strategies = std::vector<std::string>(r->result, r->result + r->result_length);
 
@@ -112,32 +149,54 @@ namespace kuzzleio {
     return ret;
   }
 
+
   void Auth::logout() noexcept {
     kuzzle_logout(_auth);
   }
+
 
   void Auth::setJwt(const std::string& jwt) noexcept {
     kuzzle_set_jwt(_kuzzle, const_cast<char*>(jwt.c_str()));
   }
 
-  std::string Auth::updateMyCredentials(const std::string& strategy, const std::string& credentials, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_update_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options))
+
+  std::string Auth::updateMyCredentials(const std::string& strategy, const std::string& credentials) {
+    query_options options;
+
+    return this->updateMyCredentials(strategy, credentials, options);
+  }
+
+  std::string Auth::updateMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_update_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
     return ret;
   }
 
-  User Auth::updateSelf(const std::string& content, query_options* options) {
-    KUZZLE_API(user_result, r, kuzzle_update_self(_auth, const_cast<char*>(content.c_str()), options))
+  User Auth::updateSelf(const std::string& content) {
+    query_options options;
+
+    return this->updateSelf(content, options);
+  }
+
+  User Auth::updateSelf(const std::string& content, const query_options& options) {
+    KUZZLE_API(user_result, r, kuzzle_update_self(_auth, const_cast<char*>(content.c_str()), const_cast<query_options*>(&options)))
 
     User ret = r->result;
     kuzzle_free_user_result(r);
     return ret;
   }
 
-  bool Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials, query_options* options) {
-    KUZZLE_API(bool_result, r, kuzzle_validate_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), options))
+
+  bool Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials) {
+    query_options options;
+
+    return this->validateMyCredentials(strategy, credentials, options);
+  }
+
+  bool Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_validate_my_credentials(_auth, const_cast<char*>(strategy.c_str()), const_cast<char*>(credentials.c_str()), const_cast<query_options*>(&options)))
 
     bool ret = r->result;
     kuzzle_free_bool_result(r);

--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -35,9 +35,7 @@ namespace kuzzleio {
   }
 
   std::string Auth::createMyCredentials(const std::string& strategy, const std::string& credentials) {
-    query_options options;
-
-    return this->createMyCredentials(strategy, credentials, options);
+    return this->createMyCredentials(strategy, credentials, query_options());
   }
 
   std::string Auth::createMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options) {
@@ -50,9 +48,7 @@ namespace kuzzleio {
   }
 
   bool Auth::credentialsExist(const std::string& strategy) {
-    query_options options;
-
-    return this->credentialsExist(strategy, options);
+    return this->credentialsExist(strategy, query_options());
   }
 
   bool Auth::credentialsExist(const std::string& strategy, const query_options& options) {
@@ -64,9 +60,7 @@ namespace kuzzleio {
   }
 
   void Auth::deleteMyCredentials(const std::string& strategy) {
-    query_options options;
-
-    this->deleteMyCredentials(strategy, options);
+    this->deleteMyCredentials(strategy, query_options());
   }
 
   void Auth::deleteMyCredentials(const std::string& strategy, const query_options& options) {
@@ -84,9 +78,7 @@ namespace kuzzleio {
 
 
   std::string Auth::getMyCredentials(const std::string& strategy) {
-    query_options options;
-
-    return this->getMyCredentials(strategy, options);
+    return this->getMyCredentials(strategy, query_options());
   }
 
   std::string Auth::getMyCredentials(const std::string& strategy, const query_options& options) {
@@ -98,9 +90,7 @@ namespace kuzzleio {
   }
 
   std::vector<std::shared_ptr<UserRight>> Auth::getMyRights() {
-    query_options options;
-
-    return this->getMyRights(options);
+    return this->getMyRights(query_options());
   }
 
   std::vector<std::shared_ptr<UserRight>> Auth::getMyRights(const query_options& options) {
@@ -119,9 +109,7 @@ namespace kuzzleio {
   }
 
   std::vector<std::string> Auth::getStrategies() {
-    query_options options;
-
-    return this->getStrategies(options);
+    return this->getStrategies(query_options());
   }
 
   std::vector<std::string> Auth::getStrategies(const query_options& options) {
@@ -161,9 +149,7 @@ namespace kuzzleio {
 
 
   std::string Auth::updateMyCredentials(const std::string& strategy, const std::string& credentials) {
-    query_options options;
-
-    return this->updateMyCredentials(strategy, credentials, options);
+    return this->updateMyCredentials(strategy, credentials, query_options());
   }
 
   std::string Auth::updateMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options) {
@@ -175,9 +161,7 @@ namespace kuzzleio {
   }
 
   User Auth::updateSelf(const std::string& content) {
-    query_options options;
-
-    return this->updateSelf(content, options);
+    return this->updateSelf(content, query_options());
   }
 
   User Auth::updateSelf(const std::string& content, const query_options& options) {
@@ -190,9 +174,7 @@ namespace kuzzleio {
 
 
   bool Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials) {
-    query_options options;
-
-    return this->validateMyCredentials(strategy, credentials, options);
+    return this->validateMyCredentials(strategy, credentials, query_options());
   }
 
   bool Auth::validateMyCredentials(const std::string& strategy, const std::string& credentials, const query_options& options) {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -30,15 +30,11 @@ namespace kuzzleio {
   }
 
   void Collection::create(const std::string& index, const std::string& collection) {
-    query_options options;
-
-    this->create(index, collection, "{}", options);
+    this->create(index, collection, "{}", query_options());
   }
 
   void Collection::create(const std::string& index, const std::string& collection, const std::string& mapping) {
-    query_options options;
-
-    this->create(index, collection, mapping, options);
+    this->create(index, collection, mapping, query_options());
   }
 
   void Collection::create(const std::string& index, const std::string& collection, const query_options& options) {
@@ -58,9 +54,7 @@ namespace kuzzleio {
 
 
   bool Collection::exists(const std::string& index, const std::string& collection) {
-    query_options options;
-
-    return this->exists(index, collection, options);
+    return this->exists(index, collection, query_options());
   }
 
   bool Collection::exists(const std::string& index, const std::string& collection, const query_options& options) {
@@ -78,9 +72,7 @@ namespace kuzzleio {
 
 
   std::string Collection::list(const std::string& index) {
-    query_options options;
-
-    return this->list(index, options);
+    return this->list(index, query_options());
   }
 
   std::string Collection::list(const std::string& index, const query_options& options) {
@@ -97,9 +89,7 @@ namespace kuzzleio {
 
 
   void Collection::truncate(const std::string& index, const std::string& collection) {
-    query_options options;
-
-    this->truncate(index, collection, options);
+    this->truncate(index, collection, query_options());
   }
 
   void Collection::truncate(const std::string& index, const std::string& collection, const query_options& options) {
@@ -114,9 +104,7 @@ namespace kuzzleio {
 
 
   std::string Collection::getMapping(const std::string& index, const std::string& collection) {
-    query_options options;
-
-    return this->getMapping(index, collection, options);
+    return this->getMapping(index, collection, query_options());
   }
 
   std::string Collection::getMapping(const std::string& index, const std::string& collection, const query_options& options) {
@@ -134,9 +122,7 @@ namespace kuzzleio {
 
 
   void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& mapping) {
-    query_options options;
-
-    this->updateMapping(index, collection, mapping, options);
+    this->updateMapping(index, collection, mapping, query_options());
   }
 
   void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& mapping, const query_options& options) {
@@ -152,9 +138,7 @@ namespace kuzzleio {
 
 
   std::string Collection::getSpecifications(const std::string& index, const std::string& collection) {
-    query_options options;
-
-    return this->getSpecifications(index, collection, options);
+    return this->getSpecifications(index, collection, query_options());
   }
 
   std::string Collection::getSpecifications(const std::string& index, const std::string& collection, const query_options& options) {
@@ -172,9 +156,7 @@ namespace kuzzleio {
 
 
   SearchResult* Collection::searchSpecifications(const std::string& query) {
-    query_options options;
-
-    return this->searchSpecifications(query, options);
+    return this->searchSpecifications(query, query_options());
   }
 
   SearchResult* Collection::searchSpecifications(const std::string& query, const query_options& options) {
@@ -188,9 +170,7 @@ namespace kuzzleio {
 
 
   std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications) {
-    query_options options;
-
-    return this->updateSpecifications(index, collection, specifications, options);
+    return this->updateSpecifications(index, collection, specifications, query_options());
   }
 
   std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, const query_options& options) {
@@ -209,9 +189,7 @@ namespace kuzzleio {
 
 
   validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications) {
-    query_options options;
-
-    return this->validateSpecifications(index, collection, specifications, options);
+    return this->validateSpecifications(index, collection, specifications, query_options());
   }
 
   validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, const query_options& options) {
@@ -227,9 +205,7 @@ namespace kuzzleio {
 
 
   void Collection::deleteSpecifications(const std::string& index, const std::string& collection) {
-    query_options options;
-
-    this->deleteSpecifications(index, collection, options);
+    this->deleteSpecifications(index, collection, query_options());
   }
 
   void Collection::deleteSpecifications(const std::string& index, const std::string& collection, const query_options& options) {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -29,44 +29,102 @@ namespace kuzzleio {
     free(_collection);
   }
 
-  void Collection::create(const std::string& index, const std::string& collection, query_options *options) {
+  void Collection::create(const std::string& index, const std::string& collection) {
+    query_options options;
+
     this->create(index, collection, "{}", options);
   }
 
-  void Collection::create(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
+  void Collection::create(const std::string& index, const std::string& collection, const std::string& mapping) {
+    query_options options;
+
+    this->create(index, collection, mapping, options);
+  }
+
+  void Collection::create(const std::string& index, const std::string& collection, const query_options& options) {
+    this->create(index, collection, "{}", options);
+  }
+
+  void Collection::create(const std::string& index, const std::string& collection, const std::string& mapping, const query_options& options) {
     KUZZLE_API(error_result, r, kuzzle_collection_create(
       _collection,
       const_cast<char*>(index.c_str()),
       const_cast<char*>(collection.c_str()),
-      const_cast<char*>(body.c_str()),
-      options))
+      const_cast<char*>(mapping.c_str()),
+      const_cast<query_options*>(&options)))
 
     kuzzle_free_error_result(r);
   }
 
-  bool Collection::exists(const std::string& index, const std::string& collection, query_options *options) {
-    KUZZLE_API(bool_result, r, kuzzle_collection_exists(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
+
+  bool Collection::exists(const std::string& index, const std::string& collection) {
+    query_options options;
+
+    return this->exists(index, collection, options);
+  }
+
+  bool Collection::exists(const std::string& index, const std::string& collection, const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_collection_exists(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<query_options*>(&options)))
 
     bool ret = r->result;
     kuzzle_free_bool_result(r);
+
     return ret;
   }
 
-  std::string Collection::list(const std::string& index, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_collection_list(_collection, const_cast<char*>(index.c_str()), options))
+
+  std::string Collection::list(const std::string& index) {
+    query_options options;
+
+    return this->list(index, options);
+  }
+
+  std::string Collection::list(const std::string& index, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_list(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  void Collection::truncate(const std::string& index, const std::string& collection, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_collection_truncate(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
+
+  void Collection::truncate(const std::string& index, const std::string& collection) {
+    query_options options;
+
+    this->truncate(index, collection, options);
+  }
+
+  void Collection::truncate(const std::string& index, const std::string& collection, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_collection_truncate(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 
-  std::string Collection::getMapping(const std::string& index, const std::string& collection, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_collection_get_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
+
+  std::string Collection::getMapping(const std::string& index, const std::string& collection) {
+    query_options options;
+
+    return this->getMapping(index, collection, options);
+  }
+
+  std::string Collection::getMapping(const std::string& index, const std::string& collection, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_get_mapping(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
@@ -74,13 +132,37 @@ namespace kuzzleio {
     return ret;
   }
 
-  void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_collection_update_mapping(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& mapping) {
+    query_options options;
+
+    this->updateMapping(index, collection, mapping, options);
+  }
+
+  void Collection::updateMapping(const std::string& index, const std::string& collection, const std::string& mapping, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_collection_update_mapping(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(mapping.c_str()),
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 
-  std::string Collection::getSpecifications(const std::string& index, const std::string& collection, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_collection_get_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
+
+  std::string Collection::getSpecifications(const std::string& index, const std::string& collection) {
+    query_options options;
+
+    return this->getSpecifications(index, collection, options);
+  }
+
+  std::string Collection::getSpecifications(const std::string& index, const std::string& collection, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_get_specifications(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
@@ -88,13 +170,36 @@ namespace kuzzleio {
     return ret;
   }
 
-  SearchResult* Collection::searchSpecifications(const std::string& body, query_options *options) {
-    KUZZLE_API(search_result, r, kuzzle_collection_search_specifications(_collection, const_cast<char*>(body.c_str()), options))
+
+  SearchResult* Collection::searchSpecifications(const std::string& query) {
+    query_options options;
+
+    return this->searchSpecifications(query, options);
+  }
+
+  SearchResult* Collection::searchSpecifications(const std::string& query, const query_options& options) {
+    KUZZLE_API(search_result, r, kuzzle_collection_search_specifications(
+      _collection,
+      const_cast<char*>(query.c_str()),
+      const_cast<query_options*>(&options)))
+
     return new SearchResult(r);
   }
 
-  std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_collection_update_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options))
+
+  std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications) {
+    query_options options;
+
+    return this->updateSpecifications(index, collection, specifications, options);
+  }
+
+  std::string Collection::updateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_collection_update_specifications(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(specifications.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
@@ -102,13 +207,38 @@ namespace kuzzleio {
     return ret;
   }
 
-  validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, query_options *options) {
-    KUZZLE_API(validation_response, r, kuzzle_collection_validate_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(specifications.c_str()), options))
+
+  validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications) {
+    query_options options;
+
+    return this->validateSpecifications(index, collection, specifications, options);
+  }
+
+  validation_response* Collection::validateSpecifications(const std::string& index, const std::string& collection, const std::string& specifications, const query_options& options) {
+    KUZZLE_API(validation_response, r, kuzzle_collection_validate_specifications(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(specifications.c_str()),
+      const_cast<query_options*>(&options)))
+
     return r;
   }
 
-  void Collection::deleteSpecifications(const std::string& index, const std::string& collection, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_collection_delete_specifications(_collection, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), options))
+
+  void Collection::deleteSpecifications(const std::string& index, const std::string& collection) {
+    query_options options;
+
+    this->deleteSpecifications(index, collection, options);
+  }
+
+  void Collection::deleteSpecifications(const std::string& index, const std::string& collection, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_collection_delete_specifications(
+      _collection,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 }

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -30,113 +30,299 @@ namespace kuzzleio {
     free(_document);
   }
 
-  int Document::count(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(int_result, r, kuzzle_document_count(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+  int Document::count(const std::string& index, const std::string& collection) {
+    query_options options;
 
-    int ret = r->result;
-    kuzzle_free_int_result(r);
-    return ret;
+    return this->count(index, collection, options);
   }
 
-  int Document::count(const std::string& index, const std::string& collection, query_options *options) {
+  int Document::count(const std::string& index, const std::string& collection, const query_options& options) {
     return this->count(index, collection, "{}", options);
   }
 
-  bool Document::exists(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
-    KUZZLE_API(bool_result, r, kuzzle_document_exists(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options))
+  int Document::count(const std::string& index, const std::string& collection, const std::string& query) {
+    query_options options;
+
+    return this->count(index, collection, options);
+  }
+
+  int Document::count(const std::string& index, const std::string& collection, const std::string& query, const query_options& options) {
+    KUZZLE_API(int_result, r, kuzzle_document_count(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(query.c_str()),
+      const_cast<query_options*>(&options)))
+
+    int ret = r->result;
+    kuzzle_free_int_result(r);
+
+    return ret;
+  }
+
+
+  bool Document::exists(const std::string& index, const std::string& collection, const std::string& id) {
+    query_options options;
+
+    return this->exists(index, collection, id, options);
+  }
+
+  bool Document::exists(const std::string& index, const std::string& collection, const std::string& id, const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_document_exists(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(id.c_str()),
+      const_cast<query_options*>(&options)))
 
     bool ret = r->result;
     kuzzle_free_bool_result(r);
+
     return ret;
   }
 
-  std::string Document::create(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_create(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::create(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
+    query_options options;
+
+    return this->create(index, collection, id, document, options);
+  }
+
+  std::string Document::create(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_create(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(id.c_str()),
+      const_cast<char*>(document.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Document::createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_create_or_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
+    query_options options;
+
+    return this->createOrReplace(index, collection, id, document, options);
+  }
+
+  std::string Document::createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_create_or_replace(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(id.c_str()),
+      const_cast<char*>(document.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Document::delete_(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_delete(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options))
+
+  std::string Document::delete_(const std::string& index, const std::string& collection, const std::string& id) {
+    query_options options;
+
+    return this->delete_(index, collection, id, options);
+  }
+
+  std::string Document::delete_(const std::string& index, const std::string& collection, const std::string& id, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_delete(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(id.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(string_array_result, r, kuzzle_document_delete_by_query(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& query) {
+    query_options options;
+
+    return this->deleteByQuery(index, collection, query, options);
+  }
+
+  std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& query, const query_options& options) {
+    KUZZLE_API(string_array_result, r, kuzzle_document_delete_by_query(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(query.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
+
     return v;
   }
 
-  std::string Document::get(const std::string& index, const std::string& collection, const std::string& id, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_get(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), options))
+
+  std::string Document::get(const std::string& index, const std::string& collection, const std::string& id) {
+    query_options options;
+
+    return this->get(index, collection, id, options);
+  }
+
+  std::string Document::get(const std::string& index, const std::string& collection, const std::string& id, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_get(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(id.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Document::replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
+    query_options options;
+
+    return this->replace(index, collection, id, document, options);
+  }
+
+  std::string Document::replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_replace(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(id.c_str()),
+      const_cast<char*>(document.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Document::update(const std::string& index, const std::string& collection, const std::string& id, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_update(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(id.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::update(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
+    query_options options;
+
+    return this->update(index, collection, id, document, options);
+  }
+
+  std::string Document::update(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_update(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(id.c_str()),
+      const_cast<char*>(document.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  bool Document::validate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(bool_result, r, kuzzle_document_validate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  bool Document::validate(const std::string& index, const std::string& collection, const std::string& document) {
+    query_options options;
+
+    return this->validate(index, collection, document, options);
+  }
+
+  bool Document::validate(const std::string& index, const std::string& collection, const std::string& document, const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_document_validate(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(document.c_str()),
+      const_cast<query_options*>(&options)))
 
     bool ret = r->result;
     kuzzle_free_bool_result(r);
+
     return ret;
   }
 
-  SearchResult* Document::search(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(search_result, r, kuzzle_document_search(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  SearchResult* Document::search(const std::string& index, const std::string& collection, const std::string& query) {
+    query_options options;
+
+    return this->search(index, collection, query, options);
+  }
+
+  SearchResult* Document::search(const std::string& index, const std::string& collection, const std::string& query, const query_options& options) {
+    KUZZLE_API(search_result, r, kuzzle_document_search(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(query.c_str()),
+      const_cast<query_options*>(&options)))
+
     return new SearchResult(r);
   }
 
-  std::string Document::mCreate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_mcreate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::mCreate(const std::string& index, const std::string& collection, const std::string& documents) {
+    query_options options;
+
+    return this->mCreate(index, collection, documents, options);
+  }
+
+  std::string Document::mCreate(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mcreate(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(documents.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Document::mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_mcreate_or_replace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& documents) {
+    query_options options;
+
+    return this->mCreateOrReplace(index, collection, documents, options);
+  }
+
+  std::string Document::mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mcreate_or_replace(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(documents.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
+
+  std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids) {
+    query_options options;
+
+    return this->mDelete(index, collection, ids, options);
+  }
+
+  std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options) {
     char **idsArray = new char *[ids.size()];
+
     for (size_t i = 0; i < ids.size(); i++) {
       idsArray[i] = const_cast<char*>(ids[i].c_str());
     }
@@ -144,16 +330,30 @@ namespace kuzzleio {
     KUZZLE_API(
       string_array_result,
       r,
-      kuzzle_document_mdelete(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), idsArray, ids.size(), options),
+      kuzzle_document_mdelete(_document,
+        const_cast<char*>(index.c_str()),
+        const_cast<char*>(collection.c_str()),
+        idsArray,
+        ids.size(),
+        const_cast<query_options*>(&options)),
       delete[] idsArray)
 
     std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
+
     return v;
   }
 
-  std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, query_options *options) {
+
+  std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids) {
+    query_options options;
+
+    return this->mGet(index, collection, ids, options);
+  }
+
+  std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options) {
     char **idsArray = new char *[ids.size()];
+
     for (size_t i = 0; i < ids.size(); i++) {
       idsArray[i] = const_cast<char*>(ids[i].c_str());
     }
@@ -161,27 +361,60 @@ namespace kuzzleio {
     KUZZLE_API(
       string_result,
       r,
-      kuzzle_document_mget(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), idsArray, ids.size(), options),
+      kuzzle_document_mget(
+        _document,
+        const_cast<char*>(index.c_str()),
+        const_cast<char*>(collection.c_str()),
+        idsArray,
+        ids.size(),
+        const_cast<query_options*>(&options)),
       delete[] idsArray)
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Document::mReplace(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_mreplace(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::mReplace(const std::string& index, const std::string& collection, const std::string& documents) {
+    query_options options;
+
+    return this->mReplace(index, collection, documents, options);
+  }
+
+  std::string Document::mReplace(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mreplace(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(documents.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Document::mUpdate(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(string_result, r, kuzzle_document_mupdate(_document, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  std::string Document::mUpdate(const std::string& index, const std::string& collection, const std::string& documents) {
+    query_options options;
+
+    return this->mUpdate(index, collection, documents, options);
+  }
+
+  std::string Document::mUpdate(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_document_mupdate(
+      _document,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(documents.c_str()),
+      const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 }

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -321,10 +321,10 @@ namespace kuzzleio {
   }
 
   std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options) {
-    char **idsArray = new char *[ids.size()];
+    char **ids_array = new char *[ids.size()];
 
     for (size_t i = 0; i < ids.size(); i++) {
-      idsArray[i] = const_cast<char*>(ids[i].c_str());
+      ids_array[i] = const_cast<char*>(ids[i].c_str());
     }
 
     KUZZLE_API(
@@ -333,10 +333,10 @@ namespace kuzzleio {
       kuzzle_document_mdelete(_document,
         const_cast<char*>(index.c_str()),
         const_cast<char*>(collection.c_str()),
-        idsArray,
+        ids_array,
         ids.size(),
         const_cast<query_options*>(&options)),
-      delete[] idsArray)
+      delete[] ids_array)
 
     std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
@@ -352,10 +352,10 @@ namespace kuzzleio {
   }
 
   std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options) {
-    char **idsArray = new char *[ids.size()];
+    char **ids_array = new char *[ids.size()];
 
     for (size_t i = 0; i < ids.size(); i++) {
-      idsArray[i] = const_cast<char*>(ids[i].c_str());
+      ids_array[i] = const_cast<char*>(ids[i].c_str());
     }
 
     KUZZLE_API(
@@ -365,10 +365,10 @@ namespace kuzzleio {
         _document,
         const_cast<char*>(index.c_str()),
         const_cast<char*>(collection.c_str()),
-        idsArray,
+        ids_array,
         ids.size(),
         const_cast<query_options*>(&options)),
-      delete[] idsArray)
+      delete[] ids_array)
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -31,9 +31,7 @@ namespace kuzzleio {
   }
 
   int Document::count(const std::string& index, const std::string& collection) {
-    query_options options;
-
-    return this->count(index, collection, options);
+    return this->count(index, collection, query_options());
   }
 
   int Document::count(const std::string& index, const std::string& collection, const query_options& options) {
@@ -41,9 +39,7 @@ namespace kuzzleio {
   }
 
   int Document::count(const std::string& index, const std::string& collection, const std::string& query) {
-    query_options options;
-
-    return this->count(index, collection, options);
+    return this->count(index, collection, query_options());
   }
 
   int Document::count(const std::string& index, const std::string& collection, const std::string& query, const query_options& options) {
@@ -62,9 +58,7 @@ namespace kuzzleio {
 
 
   bool Document::exists(const std::string& index, const std::string& collection, const std::string& id) {
-    query_options options;
-
-    return this->exists(index, collection, id, options);
+    return this->exists(index, collection, id, query_options());
   }
 
   bool Document::exists(const std::string& index, const std::string& collection, const std::string& id, const query_options& options) {
@@ -83,9 +77,7 @@ namespace kuzzleio {
 
 
   std::string Document::create(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
-    query_options options;
-
-    return this->create(index, collection, id, document, options);
+    return this->create(index, collection, id, document, query_options());
   }
 
   std::string Document::create(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
@@ -105,9 +97,7 @@ namespace kuzzleio {
 
 
   std::string Document::createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
-    query_options options;
-
-    return this->createOrReplace(index, collection, id, document, options);
+    return this->createOrReplace(index, collection, id, document, query_options());
   }
 
   std::string Document::createOrReplace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
@@ -127,9 +117,7 @@ namespace kuzzleio {
 
 
   std::string Document::delete_(const std::string& index, const std::string& collection, const std::string& id) {
-    query_options options;
-
-    return this->delete_(index, collection, id, options);
+    return this->delete_(index, collection, id, query_options());
   }
 
   std::string Document::delete_(const std::string& index, const std::string& collection, const std::string& id, const query_options& options) {
@@ -148,9 +136,7 @@ namespace kuzzleio {
 
 
   std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& query) {
-    query_options options;
-
-    return this->deleteByQuery(index, collection, query, options);
+    return this->deleteByQuery(index, collection, query, query_options());
   }
 
   std::vector<std::string> Document::deleteByQuery(const std::string& index, const std::string& collection, const std::string& query, const query_options& options) {
@@ -169,9 +155,7 @@ namespace kuzzleio {
 
 
   std::string Document::get(const std::string& index, const std::string& collection, const std::string& id) {
-    query_options options;
-
-    return this->get(index, collection, id, options);
+    return this->get(index, collection, id, query_options());
   }
 
   std::string Document::get(const std::string& index, const std::string& collection, const std::string& id, const query_options& options) {
@@ -190,9 +174,7 @@ namespace kuzzleio {
 
 
   std::string Document::replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
-    query_options options;
-
-    return this->replace(index, collection, id, document, options);
+    return this->replace(index, collection, id, document, query_options());
   }
 
   std::string Document::replace(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
@@ -212,9 +194,7 @@ namespace kuzzleio {
 
 
   std::string Document::update(const std::string& index, const std::string& collection, const std::string& id, const std::string& document) {
-    query_options options;
-
-    return this->update(index, collection, id, document, options);
+    return this->update(index, collection, id, document, query_options());
   }
 
   std::string Document::update(const std::string& index, const std::string& collection, const std::string& id, const std::string& document, const query_options& options) {
@@ -234,9 +214,7 @@ namespace kuzzleio {
 
 
   bool Document::validate(const std::string& index, const std::string& collection, const std::string& document) {
-    query_options options;
-
-    return this->validate(index, collection, document, options);
+    return this->validate(index, collection, document, query_options());
   }
 
   bool Document::validate(const std::string& index, const std::string& collection, const std::string& document, const query_options& options) {
@@ -255,9 +233,7 @@ namespace kuzzleio {
 
 
   SearchResult* Document::search(const std::string& index, const std::string& collection, const std::string& query) {
-    query_options options;
-
-    return this->search(index, collection, query, options);
+    return this->search(index, collection, query, query_options());
   }
 
   SearchResult* Document::search(const std::string& index, const std::string& collection, const std::string& query, const query_options& options) {
@@ -273,9 +249,7 @@ namespace kuzzleio {
 
 
   std::string Document::mCreate(const std::string& index, const std::string& collection, const std::string& documents) {
-    query_options options;
-
-    return this->mCreate(index, collection, documents, options);
+    return this->mCreate(index, collection, documents, query_options());
   }
 
   std::string Document::mCreate(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {
@@ -294,9 +268,7 @@ namespace kuzzleio {
 
 
   std::string Document::mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& documents) {
-    query_options options;
-
-    return this->mCreateOrReplace(index, collection, documents, options);
+    return this->mCreateOrReplace(index, collection, documents, query_options());
   }
 
   std::string Document::mCreateOrReplace(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {
@@ -315,9 +287,7 @@ namespace kuzzleio {
 
 
   std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids) {
-    query_options options;
-
-    return this->mDelete(index, collection, ids, options);
+    return this->mDelete(index, collection, ids, query_options());
   }
 
   std::vector<std::string> Document::mDelete(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options) {
@@ -346,9 +316,7 @@ namespace kuzzleio {
 
 
   std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids) {
-    query_options options;
-
-    return this->mGet(index, collection, ids, options);
+    return this->mGet(index, collection, ids, query_options());
   }
 
   std::string Document::mGet(const std::string& index, const std::string& collection, const std::vector<std::string>& ids, const query_options& options) {
@@ -378,9 +346,7 @@ namespace kuzzleio {
 
 
   std::string Document::mReplace(const std::string& index, const std::string& collection, const std::string& documents) {
-    query_options options;
-
-    return this->mReplace(index, collection, documents, options);
+    return this->mReplace(index, collection, documents, query_options());
   }
 
   std::string Document::mReplace(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {
@@ -399,9 +365,7 @@ namespace kuzzleio {
 
 
   std::string Document::mUpdate(const std::string& index, const std::string& collection, const std::string& documents) {
-    query_options options;
-
-    return this->mUpdate(index, collection, documents, options);
+    return this->mUpdate(index, collection, documents, query_options());
   }
 
   std::string Document::mUpdate(const std::string& index, const std::string& collection, const std::string& documents, const query_options& options) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -30,9 +30,7 @@ namespace kuzzleio {
   }
 
   void Index::create(const std::string& index) {
-    query_options options;
-
-    this->create(index, options);
+    this->create(index, query_options());
   }
 
   void Index::create(const std::string& index, const query_options& options) {
@@ -46,9 +44,7 @@ namespace kuzzleio {
 
 
   void Index::delete_(const std::string& index) {
-    query_options options;
-
-    this->delete_(index, options);
+    this->delete_(index, query_options());
   }
 
   void Index::delete_(const std::string& index, const query_options& options) {
@@ -62,9 +58,7 @@ namespace kuzzleio {
 
 
   std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes) {
-    query_options options;
-
-    return this->mDelete(indexes, options);
+    return this->mDelete(indexes, query_options());
   }
 
   std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes, const query_options& options) {
@@ -89,9 +83,7 @@ namespace kuzzleio {
 
 
   bool Index::exists(const std::string& index) {
-    query_options options;
-
-    return this->exists(index, options);
+    return this->exists(index, query_options());
   }
 
   bool Index::exists(const std::string& index, const query_options& options) {
@@ -108,9 +100,7 @@ namespace kuzzleio {
 
 
   void Index::refresh(const std::string& index) {
-    query_options options;
-
-    this->refresh(index, options);
+    this->refresh(index, query_options());
   }
 
   void Index::refresh(const std::string& index, const query_options& options) {
@@ -124,9 +114,7 @@ namespace kuzzleio {
 
 
   void Index::refreshInternal() {
-    query_options options;
-
-    this->refreshInternal(options);
+    this->refreshInternal(query_options());
   }
 
   void Index::refreshInternal(const query_options& options) {
@@ -139,9 +127,7 @@ namespace kuzzleio {
 
 
   void Index::setAutoRefresh(const std::string& index, bool auto_refresh) {
-    query_options options;
-
-    this->setAutoRefresh(index, auto_refresh, options);
+    this->setAutoRefresh(index, auto_refresh, query_options());
   }
 
   void Index::setAutoRefresh(const std::string& index, bool auto_refresh, const query_options& options) {
@@ -156,9 +142,7 @@ namespace kuzzleio {
 
 
   bool Index::getAutoRefresh(const std::string& index) {
-    query_options options;
-
-    return this->getAutoRefresh(index, options);
+    return this->getAutoRefresh(index, query_options());
   }
 
   bool Index::getAutoRefresh(const std::string& index, const query_options& options) {
@@ -175,9 +159,7 @@ namespace kuzzleio {
 
 
   std::vector<std::string> Index::list() {
-    query_options options;
-
-    return this->list(options);
+    return this->list(query_options());
   }
 
   std::vector<std::string> Index::list(const query_options& options) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -29,70 +29,165 @@ namespace kuzzleio {
     free(_index);
   }
 
-  void Index::create(const std::string& index, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_index_create(_index, const_cast<char*>(index.c_str()), options))
+  void Index::create(const std::string& index) {
+    query_options options;
+
+    this->create(index, options);
+  }
+
+  void Index::create(const std::string& index, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_index_create(
+      _index,
+      const_cast<char*>(index.c_str()),
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 
-  void Index::delete_(const std::string& index, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_index_delete(_index, const_cast<char*>(index.c_str()), options))
+
+  void Index::delete_(const std::string& index) {
+    query_options options;
+
+    this->delete_(index, options);
+  }
+
+  void Index::delete_(const std::string& index, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_index_delete(
+      _index,
+      const_cast<char*>(index.c_str()),
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 
-  std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes, query_options *options) {
-    char **indexesArray = new char *[indexes.size()];
+
+  std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes) {
+    query_options options;
+
+    return this->mDelete(indexes, options);
+  }
+
+  std::vector<std::string> Index::mDelete(const std::vector<std::string>& indexes, const query_options& options) {
+    char **indexes_array = new char *[indexes.size()];
+
     for (size_t i = 0; i < indexes.size(); i++) {
-      indexesArray[i] = const_cast<char*>(indexes[i].c_str());
+      indexes_array[i] = const_cast<char*>(indexes[i].c_str());
     }
 
     KUZZLE_API(
       string_array_result,
       r,
-      kuzzle_index_mdelete(_index, indexesArray, indexes.size(), options),
-      delete[] indexesArray
+      kuzzle_index_mdelete(_index, indexes_array, indexes.size(), const_cast<query_options*>(&options)),
+      delete[] indexes_array
     )
 
     std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
+
     return v;
   }
 
-  bool Index::exists(const std::string& index, query_options *options) {
-    KUZZLE_API(bool_result, r, kuzzle_index_exists(_index, const_cast<char*>(index.c_str()), options))
+
+  bool Index::exists(const std::string& index) {
+    query_options options;
+
+    return this->exists(index, options);
+  }
+
+  bool Index::exists(const std::string& index, const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_index_exists(
+      _index,
+      const_cast<char*>(index.c_str()),
+      const_cast<query_options*>(&options)))
 
     bool ret = r->result;
     kuzzle_free_bool_result(r);
+
     return ret;
   }
 
-  void Index::refresh(const std::string& index, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_index_refresh(_index, const_cast<char*>(index.c_str()), options))
+
+  void Index::refresh(const std::string& index) {
+    query_options options;
+
+    this->refresh(index, options);
+  }
+
+  void Index::refresh(const std::string& index, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_index_refresh(
+      _index,
+      const_cast<char*>(index.c_str()),
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 
-  void Index::refreshInternal(query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_index_refresh_internal(_index, options))
+
+  void Index::refreshInternal() {
+    query_options options;
+
+    this->refreshInternal(options);
+  }
+
+  void Index::refreshInternal(const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_index_refresh_internal(
+      _index,
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 
-  void Index::setAutoRefresh(const std::string& index, bool autoRefresh, query_options *options) {
-    KUZZLE_API(error_result, r, kuzzle_index_set_auto_refresh(_index, const_cast<char*>(index.c_str()), autoRefresh, options))
+
+  void Index::setAutoRefresh(const std::string& index, bool auto_refresh) {
+    query_options options;
+
+    this->setAutoRefresh(index, auto_refresh, options);
+  }
+
+  void Index::setAutoRefresh(const std::string& index, bool auto_refresh, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_index_set_auto_refresh(
+      _index,
+      const_cast<char*>(index.c_str()),
+      auto_refresh,
+      const_cast<query_options*>(&options)))
+
     kuzzle_free_error_result(r);
   }
 
-  bool Index::getAutoRefresh(const std::string& index, query_options *options) {
-    KUZZLE_API(bool_result, r, kuzzle_index_get_auto_refresh(_index, const_cast<char*>(index.c_str()), options))
+
+  bool Index::getAutoRefresh(const std::string& index) {
+    query_options options;
+
+    return this->getAutoRefresh(index, options);
+  }
+
+  bool Index::getAutoRefresh(const std::string& index, const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_index_get_auto_refresh(
+      _index,
+      const_cast<char*>(index.c_str()),
+      const_cast<query_options*>(&options)))
 
     bool ret = r->result;
     kuzzle_free_bool_result(r);
+
     return ret;
   }
 
-  std::vector<std::string> Index::list(query_options *options) {
-    KUZZLE_API(string_array_result, r, kuzzle_index_list(_index, options))
+
+  std::vector<std::string> Index::list() {
+    query_options options;
+
+    return this->list(options);
+  }
+
+  std::vector<std::string> Index::list(const query_options& options) {
+    KUZZLE_API(string_array_result, r, kuzzle_index_list(
+      _index,
+      const_cast<query_options*>(&options)))
 
     std::vector<std::string> v = std::vector<std::string>(r->result, r->result + r->result_length);
     kuzzle_free_string_array_result(r);
+
     return v;
   }
 }

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -138,7 +138,9 @@ namespace kuzzleio {
     return what();
   }
 
-  Kuzzle::Kuzzle(Protocol* proto, options *opts) {
+  Kuzzle::Kuzzle(Protocol* proto) : Kuzzle(proto, options()) {}
+
+  Kuzzle::Kuzzle(Protocol* proto, const options& options) {
     this->_kuzzle = new kuzzle();
 
     proto->_protocol = new protocol();
@@ -166,7 +168,7 @@ namespace kuzzleio {
     this->_protocol = proto->_protocol;
     this->_cpp_protocol = proto;
 
-    kuzzle_new_kuzzle(this->_kuzzle, this->_protocol, opts);
+    kuzzle_new_kuzzle(this->_kuzzle, this->_protocol, const_cast<kuzzleio::options*>(&options));
 
     this->document = new Document(_kuzzle);
     this->auth = new Auth(_kuzzle);
@@ -179,6 +181,7 @@ namespace kuzzleio {
   Kuzzle::~Kuzzle() {
     unregisterKuzzle(this->_kuzzle);
     unregisterProtocol(this->_protocol);
+
     delete(this->_kuzzle);
     delete(this->document);
     delete(this->auth);
@@ -190,7 +193,8 @@ namespace kuzzleio {
 
   void Kuzzle::connect() {
     char * err = kuzzle_connect(_kuzzle);
-    if (err != NULL) {
+
+    if (err != nullptr) {
       const std::string cppError = err;
       free(err);
       throw InternalException(cppError);
@@ -201,8 +205,18 @@ namespace kuzzleio {
     kuzzle_disconnect(_kuzzle);
   }
 
-  kuzzle_response* Kuzzle::query(kuzzle_request* query, query_options* options) {
-    KUZZLE_API(kuzzle_response, r, kuzzle_query(_kuzzle, query, options))
+  kuzzle_response* Kuzzle::query(const kuzzle_request& request) {
+    query_options options;
+
+    return this->query(request, options);
+  }
+
+  kuzzle_response* Kuzzle::query(const kuzzle_request& request, const query_options& options) {
+    KUZZLE_API(kuzzle_response, r, kuzzle_query(
+      _kuzzle,
+      const_cast<kuzzle_request*>(&request),
+      const_cast<query_options*>(&options)))
+
     return r;
   }
 
@@ -211,8 +225,8 @@ namespace kuzzleio {
     return this;
   }
 
-  Kuzzle* Kuzzle::setAutoReplay(bool autoReplay) noexcept {
-    kuzzle_set_auto_replay(_kuzzle, autoReplay);
+  Kuzzle* Kuzzle::setAutoReplay(bool auto_replay) noexcept {
+    kuzzle_set_auto_replay(_kuzzle, auto_replay);
     return this;
   }
 
@@ -231,8 +245,8 @@ namespace kuzzleio {
     return this;
   }
 
-  Kuzzle* Kuzzle::setVolatile(const std::string& volatiles) noexcept {
-    kuzzle_set_volatile(_kuzzle, const_cast<char*>(volatiles.c_str()));
+  Kuzzle* Kuzzle::setVolatile(const std::string& volatile_data) noexcept {
+    kuzzle_set_volatile(_kuzzle, const_cast<char*>(volatile_data.c_str()));
     return this;
   }
 
@@ -248,8 +262,9 @@ namespace kuzzleio {
     return _cpp_protocol;
   }
 
-  void trigger_event_listener(int event, char* res, void* data) {
-    EventListener* listener = static_cast<Kuzzle*>(data)->getListeners()[event];
+  void trigger_event_listener(int event, char* res, void* kuzzle_instance) {
+    EventListener* listener = static_cast<Kuzzle*>(kuzzle_instance)->getListeners()[event];
+
     if (listener) {
       (*listener)(res);
     }
@@ -259,8 +274,8 @@ namespace kuzzleio {
     return _listener_instances;
   }
 
-  void Kuzzle::emitEvent(Event event, const std::string& body) noexcept {
-    kuzzle_emit_event(_kuzzle, event, const_cast<char*>(body.c_str()));
+  void Kuzzle::emitEvent(Event event, const std::string& payload) noexcept {
+    kuzzle_emit_event(_kuzzle, event, const_cast<char*>(payload.c_str()));
   }
 
   KuzzleEventEmitter* Kuzzle::addListener(Event event, EventListener* listener) {

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -206,9 +206,7 @@ namespace kuzzleio {
   }
 
   kuzzle_response* Kuzzle::query(const kuzzle_request& request) {
-    query_options options;
-
-    return this->query(request, options);
+    return this->query(request, query_options());
   }
 
   kuzzle_response* Kuzzle::query(const kuzzle_request& request, const query_options& options) {

--- a/src/realtime.cpp
+++ b/src/realtime.cpp
@@ -47,9 +47,7 @@ namespace kuzzleio {
 
 
   int Realtime::count(const std::string& room_id) {
-    query_options options;
-
-    return this->count(room_id, options);
+    return this->count(room_id, query_options());
   }
 
   int Realtime::count(const std::string& room_id, const query_options& options) {
@@ -66,9 +64,7 @@ namespace kuzzleio {
 
 
   void Realtime::publish(const std::string& index, const std::string& collection, const std::string& message) {
-    query_options options;
-
-    this->publish(index, collection, message, options);
+    this->publish(index, collection, message, query_options());
   }
 
   void Realtime::publish(const std::string& index, const std::string& collection, const std::string& message, const query_options& options) {
@@ -84,9 +80,7 @@ namespace kuzzleio {
 
 
   std::string Realtime::subscribe(const std::string& index, const std::string& collection, const std::string& filters, NotificationListener* listener) {
-    room_options options;
-
-    return this->subscribe(index, collection, filters, listener, options);
+    return this->subscribe(index, collection, filters, listener, room_options());
   }
 
   std::string Realtime::subscribe(const std::string& index, const std::string& collection, const std::string& filters, NotificationListener* listener, const room_options& options) {
@@ -108,9 +102,7 @@ namespace kuzzleio {
 
 
   void Realtime::unsubscribe(const std::string& room_id) {
-    query_options options;
-
-    return this->unsubscribe(room_id, options);
+    return this->unsubscribe(room_id, query_options());
   }
 
   void Realtime::unsubscribe(const std::string& room_id, const query_options& options) {

--- a/src/realtime.cpp
+++ b/src/realtime.cpp
@@ -29,24 +29,15 @@ namespace kuzzleio {
     free(_realtime);
   }
 
-  int Realtime::count(const std::string& roomId, query_options *options) {
-    KUZZLE_API(
-      int_result,
-      r,
-      kuzzle_realtime_count(_realtime, const_cast<char*>(roomId.c_str()), options))
-
-    int ret = r->result;
-    kuzzle_free_int_result(r);
-    return ret;
+  // Internal use only
+  NotificationListener* Realtime::getListener(const std::string& room_id) {
+    return _listener_instances[room_id];
   }
 
-  NotificationListener* Realtime::getListener(const std::string& roomId) {
-    return _listener_instances[roomId];
-  }
-
-  void call_subscribe_cb(notification_result* res, void* data) {
-    if (data) {
-      NotificationListener* listener = static_cast<Realtime*>(data)->getListener(res->room_id);
+  // Internal use only
+  void call_subscribe_cb(notification_result* res, void* realtime_controller) {
+    if (realtime_controller) {
+      NotificationListener* listener = static_cast<Realtime*>(realtime_controller)->getListener(res->room_id);
 
       if (listener) {
         (*listener)(res);
@@ -54,34 +45,81 @@ namespace kuzzleio {
     }
   }
 
-  void Realtime::publish(const std::string& index, const std::string& collection, const std::string& body, query_options *options) {
-    KUZZLE_API(
-      error_result,
-      r,
-      kuzzle_realtime_publish(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()), const_cast<char*>(body.c_str()), options))
+
+  int Realtime::count(const std::string& room_id) {
+    query_options options;
+
+    return this->count(room_id, options);
+  }
+
+  int Realtime::count(const std::string& room_id, const query_options& options) {
+    KUZZLE_API(int_result, r, kuzzle_realtime_count(
+      _realtime,
+      const_cast<char*>(room_id.c_str()),
+      const_cast<query_options*>(&options)))
+
+    int ret = r->result;
+    kuzzle_free_int_result(r);
+
+    return ret;
+  }
+
+
+  void Realtime::publish(const std::string& index, const std::string& collection, const std::string& message) {
+    query_options options;
+
+    this->publish(index, collection, message, options);
+  }
+
+  void Realtime::publish(const std::string& index, const std::string& collection, const std::string& message, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_realtime_publish(
+      _realtime,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(message.c_str()),
+      const_cast<query_options*>(&options)))
 
     kuzzle_free_error_result(r);
   }
 
-  std::string Realtime::subscribe(const std::string& index, const std::string& collection, const std::string& body, NotificationListener* cb, room_options* options) {
-    KUZZLE_API(
-      subscribe_result,
-      r,
-      kuzzle_realtime_subscribe(_realtime, const_cast<char*>(index.c_str()), const_cast<char*>(collection.c_str()),  const_cast<char*>(body.c_str()), call_subscribe_cb, this, options))
 
-    std::string roomId = r->room;
-    _listener_instances[r->channel] = cb;
-    kuzzle_free_subscribe_result(r);
-    return roomId;
+  std::string Realtime::subscribe(const std::string& index, const std::string& collection, const std::string& filters, NotificationListener* listener) {
+    room_options options;
+
+    return this->subscribe(index, collection, filters, listener, options);
   }
 
-  void Realtime::unsubscribe(const std::string& roomId, query_options *options) {
-    KUZZLE_API(
-      error_result,
-      r,
-      kuzzle_realtime_unsubscribe(_realtime, const_cast<char*>(roomId.c_str()), options))
+  std::string Realtime::subscribe(const std::string& index, const std::string& collection, const std::string& filters, NotificationListener* listener, const room_options& options) {
+    KUZZLE_API(subscribe_result, r, kuzzle_realtime_subscribe(
+      _realtime,
+      const_cast<char*>(index.c_str()),
+      const_cast<char*>(collection.c_str()),
+      const_cast<char*>(filters.c_str()),
+      call_subscribe_cb,
+      this,
+      const_cast<room_options*>(&options)))
 
-    _listener_instances[roomId] = nullptr;
+    std::string room_id = r->room;
+    _listener_instances[r->channel] = listener;
+    kuzzle_free_subscribe_result(r);
+
+    return room_id;
+  }
+
+
+  void Realtime::unsubscribe(const std::string& room_id) {
+    query_options options;
+
+    return this->unsubscribe(room_id, options);
+  }
+
+  void Realtime::unsubscribe(const std::string& room_id, const query_options& options) {
+    KUZZLE_API(error_result, r, kuzzle_realtime_unsubscribe(
+      _realtime,
+      const_cast<char*>(room_id.c_str()),
+      const_cast<query_options*>(&options)))
+
+    _listener_instances[room_id] = nullptr;
     kuzzle_free_error_result(r);
   }
 }

--- a/src/search_result.cpp
+++ b/src/search_result.cpp
@@ -16,9 +16,9 @@
 #include "internal/core.hpp"
 
 namespace kuzzleio {
-    SearchResult::SearchResult(search_result* sr) {
-        _sr = sr;
-
+    SearchResult::SearchResult(const search_result* sr)
+      : _sr(sr)
+    {
         aggregations = std::string(_sr->aggregations);
         hits = std::string(_sr->hits);
         total = _sr->total;
@@ -27,11 +27,11 @@ namespace kuzzleio {
     }
 
     SearchResult::~SearchResult() {
-        kuzzle_free_search_result(_sr);
+        kuzzle_free_search_result(const_cast<search_result*>(_sr));
     }
 
-    SearchResult* SearchResult::next() {
-        search_result *sr = kuzzle_document_search_next(_sr);
+    SearchResult* SearchResult::next() const{
+        search_result *sr = kuzzle_document_search_next(const_cast<search_result*>(_sr));
         return new SearchResult(sr);
     }
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -30,9 +30,7 @@ namespace kuzzleio {
   }
 
   bool Server::adminExists() {
-    query_options options;
-
-    return this->adminExists(options);
+    return this->adminExists(query_options());
   }
 
   bool Server::adminExists(const query_options& options) {
@@ -46,9 +44,7 @@ namespace kuzzleio {
 
 
   std::string Server::getAllStats() {
-    query_options options;
-
-    return this->getAllStats(options);
+    return this->getAllStats(query_options());
   }
 
   std::string Server::getAllStats(const query_options& options) {
@@ -62,9 +58,7 @@ namespace kuzzleio {
 
 
   std::string Server::getStats(time_t start, time_t end) {
-    query_options options;
-
-    return this->getStats(start, end, options);
+    return this->getStats(start, end, query_options());
   }
 
   std::string Server::getStats(time_t start, time_t end, const query_options& options) {
@@ -78,9 +72,7 @@ namespace kuzzleio {
 
 
   std::string Server::getLastStats() {
-    query_options options;
-
-    return this->getLastStats(options);
+    return this->getLastStats(query_options());
   }
 
   std::string Server::getLastStats(const query_options& options) {
@@ -94,9 +86,7 @@ namespace kuzzleio {
 
 
   std::string Server::getConfig() {
-    query_options options;
-
-    return this->getConfig(options);
+    return this->getConfig(query_options());
   }
 
   std::string Server::getConfig(const query_options& options) {
@@ -110,9 +100,7 @@ namespace kuzzleio {
 
 
   std::string Server::info() {
-    query_options options;
-
-    return this->info(options);
+    return this->info(query_options());
   }
 
   std::string Server::info(const query_options& options) {
@@ -126,9 +114,7 @@ namespace kuzzleio {
 
 
   long long Server::now() {
-    query_options options;
-
-    return this->now(options);
+    return this->now(query_options());
   }
 
   // java wrapper for this method is in typemap.i

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -29,55 +29,115 @@ namespace kuzzleio {
     free(_server);
   }
 
-  bool Server::adminExists(query_options *options) {
-    KUZZLE_API(bool_result, r, kuzzle_admin_exists(_server, options))
+  bool Server::adminExists() {
+    query_options options;
+
+    return this->adminExists(options);
+  }
+
+  bool Server::adminExists(const query_options& options) {
+    KUZZLE_API(bool_result, r, kuzzle_admin_exists(_server, const_cast<query_options*>(&options)))
+
     bool ret = r->result;
     kuzzle_free_bool_result(r);
+
     return ret;
   }
 
-  std::string Server::getAllStats(query_options* options) {
-    KUZZLE_API(string_result, r, kuzzle_get_all_stats(_server, options))
+
+  std::string Server::getAllStats() {
+    query_options options;
+
+    return this->getAllStats(options);
+  }
+
+  std::string Server::getAllStats(const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_get_all_stats(_server, const_cast<query_options*>(&options)))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Server::getStats(time_t start, time_t end, query_options* options) {
-    KUZZLE_API(string_result, r, kuzzle_get_stats(_server, start, end, options))
+
+  std::string Server::getStats(time_t start, time_t end) {
+    query_options options;
+
+    return this->getStats(start, end, options);
+  }
+
+  std::string Server::getStats(time_t start, time_t end, const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_get_stats(_server, start, end, const_cast<query_options*>(&options)))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Server::getLastStats(query_options* options) {
-    KUZZLE_API(string_result, r, kuzzle_get_last_stats(_server, options))
+
+  std::string Server::getLastStats() {
+    query_options options;
+
+    return this->getLastStats(options);
+  }
+
+  std::string Server::getLastStats(const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_get_last_stats(_server, const_cast<query_options*>(&options)))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Server::getConfig(query_options* options) {
-    KUZZLE_API(string_result, r, kuzzle_get_config(_server, options))
+
+  std::string Server::getConfig() {
+    query_options options;
+
+    return this->getConfig(options);
+  }
+
+  std::string Server::getConfig(const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_get_config(_server, const_cast<query_options*>(&options)))
+
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
   }
 
-  std::string Server::info(query_options* options) {
-    KUZZLE_API(string_result, r, kuzzle_info(_server, options))
+
+  std::string Server::info() {
+    query_options options;
+
+    return this->info(options);
+  }
+
+  std::string Server::info(const query_options& options) {
+    KUZZLE_API(string_result, r, kuzzle_info(_server, const_cast<query_options*>(&options)))
 
     std::string ret = r->result;
     kuzzle_free_string_result(r);
+
     return ret;
+  }
+
+
+  long long Server::now() {
+    query_options options;
+
+    return this->now(options);
   }
 
   // java wrapper for this method is in typemap.i
-  long long Server::now(query_options* options) {
-    KUZZLE_API(date_result, r, kuzzle_now(_server, options))
+  long long Server::now(const query_options& options) {
+    KUZZLE_API(date_result, r, kuzzle_now(_server, const_cast<query_options*>(&options)))
 
     long long ret = r->result;
     kuzzle_free_date_result(r);
+
     return ret;
   }
 }

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -1,10 +1,12 @@
 #include "websocket.hpp"
 
 namespace kuzzleio {
-  WebSocket::WebSocket(const std::string& host, options *opts) {
+  WebSocket::WebSocket(const std::string& host) : WebSocket(host, options()) {}
+
+  WebSocket::WebSocket(const std::string& host, const options& options) {
     this->_web_socket = new web_socket();
 
-    kuzzle_websocket_new_web_socket(this->_web_socket, const_cast<char*>(host.c_str()), opts, this);
+    kuzzle_websocket_new_web_socket(this->_web_socket, const_cast<char*>(host.c_str()), const_cast<kuzzleio::options*>(&options), this);
   }
 
   void trigger_websocket_event_listener(int event, char* res, void* data) {

--- a/test/features/step_definitions/collection-steps.cpp
+++ b/test/features/step_definitions/collection-steps.cpp
@@ -81,7 +81,7 @@ namespace {
     query_options options;
     options.refresh = const_cast<char*>("wait_for");
 
-    ctx->kuzzle->document->create(ctx->index, ctx->collection, document_id, "{\"a\":\"document\"}", &options);
+    ctx->kuzzle->document->create(ctx->index, ctx->collection, document_id, "{\"a\":\"document\"}", options);
   }
 
   WHEN("^I truncate the collection \'([^\"]*)\'$")
@@ -93,7 +93,7 @@ namespace {
     query_options options;
     options.refresh = const_cast<char*>("wait_for");
 
-    ctx->kuzzle->collection->truncate(ctx->index, collection_id, &options);
+    ctx->kuzzle->collection->truncate(ctx->index, collection_id, options);
   }
 
   THEN("^the collection \'([^\"]*)\' should be empty$")

--- a/test/features/step_definitions/document-steps.cpp
+++ b/test/features/step_definitions/document-steps.cpp
@@ -12,7 +12,7 @@ namespace {
       query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->create(ctx->index, ctx->collection, document_id, "{\"a\":\"document\"}", &options);
+      ctx->kuzzle->document->create(ctx->index, ctx->collection, document_id, "{\"a\":\"document\"}", options);
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
@@ -46,7 +46,7 @@ namespace {
       query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id, &options);
+      ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id, options);
     } catch (KuzzleException e) {
       ctx->error_message = e.getMessage();
       ctx->success = 0;
@@ -62,7 +62,7 @@ namespace {
       query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->createOrReplace(ctx->index, ctx->collection, document_id, "{\"a\":\"replaced document\"}", &options);
+      ctx->kuzzle->document->createOrReplace(ctx->index, ctx->collection, document_id, "{\"a\":\"replaced document\"}", options);
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
@@ -90,7 +90,7 @@ namespace {
       query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->replace(ctx->index, ctx->collection, document_id, "{\"a\":\"replaced document\"}", &options);
+      ctx->kuzzle->document->replace(ctx->index, ctx->collection, document_id, "{\"a\":\"replaced document\"}", options);
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
@@ -115,7 +115,7 @@ namespace {
       query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\"a\":\"updated document\"}", &options);
+      ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\"a\":\"updated document\"}", options);
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
@@ -160,7 +160,7 @@ namespace {
       options.from = from;
       options.size = size;
 
-      ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, query, &options);
+      ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, query, options);
     } catch (KuzzleException e) {
       BOOST_FAIL(e.getMessage());
     }
@@ -217,7 +217,7 @@ namespace {
       document_ids.push_back(document1_id);
       document_ids.push_back(document2_id);
 
-      ctx->kuzzle->document->mDelete(ctx->index, ctx->collection, document_ids, &options);
+      ctx->kuzzle->document->mDelete(ctx->index, ctx->collection, document_ids, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
     } catch (PartialException e) {
@@ -253,7 +253,7 @@ namespace {
       options.refresh = const_cast<char*>("wait_for");
 
       string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{}}, {\"_id\":\"" + document2_id + "\", \"body\":{}}]";
-      ctx->kuzzle->document->mCreate(ctx->index, ctx->collection, documents, &options);
+      ctx->kuzzle->document->mCreate(ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
     } catch (PartialException e) {
@@ -276,7 +276,7 @@ namespace {
       options.refresh = const_cast<char*>("wait_for");
 
       string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{\"a\":\"replaced document\"}}, {\"_id\":\"" + document2_id + "\", \"body\":{\"a\":\"replaced document\"}}]";
-      ctx->kuzzle->document->mReplace(ctx->index, ctx->collection, documents, &options);
+      ctx->kuzzle->document->mReplace(ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
     } catch (PartialException e) {
@@ -310,7 +310,7 @@ namespace {
       options.refresh = const_cast<char*>("wait_for");
 
       string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{\"a\":\"replaced document\"}}, {\"_id\":\"" + document2_id + "\", \"body\":{\"a\":\"replaced document\"}}]";
-      ctx->kuzzle->document->mUpdate(ctx->index, ctx->collection, documents, &options);
+      ctx->kuzzle->document->mUpdate(ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
     } catch (PartialException e) {
@@ -344,7 +344,7 @@ namespace {
       options.refresh = const_cast<char*>("wait_for");
 
       string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{\"a\":\"replaced document\"}}, {\"_id\":\"" + document2_id + "\", \"body\":{\"a\":\"replaced document\"}}]";
-      ctx->kuzzle->document->mCreateOrReplace(ctx->index, ctx->collection, documents, &options);
+      ctx->kuzzle->document->mCreateOrReplace(ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
     } catch (PartialException e) {

--- a/test/features/step_definitions/kuzzle-sdk-steps.cpp
+++ b/test/features/step_definitions/kuzzle-sdk-steps.cpp
@@ -102,7 +102,7 @@ namespace {
 
     try {
       ctx->protocol = new WebSocket(hostname);
-      ctx->kuzzle = new Kuzzle(ctx->protocol, &ctx->kuzzle_options);
+      ctx->kuzzle = new Kuzzle(ctx->protocol, ctx->kuzzle_options);
     } catch (KuzzleException e) {
       K_LOG_E(e.getMessage().c_str());
     }

--- a/test/features/step_definitions/kuzzle_utils.cpp
+++ b/test/features/step_definitions/kuzzle_utils.cpp
@@ -74,7 +74,7 @@ bool kuzzle_user_exists(Kuzzle *kuzzle, const string &user_id)
     req.controller = "security";
     req.action = "getUser";
     req.id = user_id.c_str();
-    kuzzle->query(&req);
+    kuzzle->query(req);
     user_exists = true;
   }
   catch (kuzzleio::NotFoundException e)
@@ -101,8 +101,7 @@ void kuzzle_user_delete(Kuzzle *kuzzle, const string &user_id)
     query_options options;
     options.refresh = const_cast<char*>("wait_for");
     options.volatiles = const_cast<char*>("{}");
-    kuzzle->query(
-        &req, &options); // TODO: test if we can delete with options
+    kuzzle->query(req, options); // TODO: test if we can delete with options
 
     K_LOG_D("Deleted user \"%s\"", user_id.c_str());
   }
@@ -123,7 +122,7 @@ void kuzzle_credentials_delete(Kuzzle *kuzzle, const string &strategy,
     req.strategy = "local";
     req.id = user_id.c_str();
 
-    kuzzle->query(&req);
+    kuzzle->query(req);
 
     K_LOG_D("Deleted '%s' credentials for userId '%s'", strategy.c_str(),
             user_id.c_str());
@@ -163,7 +162,7 @@ void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
   K_LOG_D("Req body: %s", req.body);
   try
   {
-    kuzzle_response *resp = kuzzle->query(&req);
+    kuzzle_response *resp = kuzzle->query(req);
     K_LOG_D("createUser ended with status: %d", resp->status);
   }
   catch (KuzzleException e)

--- a/test/features/step_definitions/realtime-steps.cpp
+++ b/test/features/step_definitions/realtime-steps.cpp
@@ -30,7 +30,7 @@ namespace {
     options.refresh = const_cast<char*>("wait_for");
 
     try {
-      ctx->kuzzle->document->create(ctx->index, ctx->collection, "", "{\"foo\":\"bar\"}", &options);
+      ctx->kuzzle->document->create(ctx->index, ctx->collection, "", R"({"foo":"bar"})", options);
     } catch (KuzzleException e) {
       BOOST_FAIL(e.getMessage());
     }
@@ -72,7 +72,7 @@ namespace {
     options.refresh = const_cast<char*>("wait_for");
 
     try {
-      ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\""+key+"\":\""+value+"\"}", &options);
+      ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\""+key+"\":\""+value+"\"}", options);
     } catch (KuzzleException e) {
       BOOST_FAIL(e.getMessage());
     }


### PR DESCRIPTION
## What does this PR do ?

Use multi signature methods instead of having default arguments.  
All methods takes a `const query_options&` instead of a `query_options*`. Same for `room_options`, `kuzzle_request` and `options`.

Documentation: https://github.com/kuzzleio/documentation-V2/pull/206

### How should this be manually tested?

  - Step 1 : Run tests

### Other changes

 - Add const qualifier in SearchResult