### PR TITLE
Add status getter for exceptions

### DIFF
--- a/include/internal/exceptions.hpp
+++ b/include/internal/exceptions.hpp
@@ -35,7 +35,6 @@ namespace kuzzleio {
 
   class KuzzleException : public std::runtime_error {
     private:
-      const std::string _message;
       const int _status;
 
     public:

--- a/include/internal/exceptions.hpp
+++ b/include/internal/exceptions.hpp
@@ -49,13 +49,17 @@ namespace kuzzleio {
 
       KuzzleException(const KuzzleException& ke)
       : _status(ke.status()),
-        std::runtime_error(ke.getMessage()) {};
+        std::runtime_error(ke.what()) {};
 
       virtual ~KuzzleException() throw() {};
 
       std::string getMessage() const {
         return what();
       };
+
+      std::string message() const {
+        return what();
+      }
 
       int status() const {
         return _status;
@@ -67,61 +71,61 @@ namespace kuzzleio {
     public:
       BadRequestException(const std::string& message="Bad Request Exception")
         : KuzzleException(BAD_REQUEST_EXCEPTION, message) {};
-      BadRequestException(const BadRequestException& bre) : KuzzleException(bre.status(), bre.getMessage()) {}
+      BadRequestException(const BadRequestException& bre) : KuzzleException(bre.status(), bre.what()) {}
   };
   class ForbiddenException: public KuzzleException {
     public:
       ForbiddenException(const std::string& message="Forbidden Exception")
         : KuzzleException(FORBIDDEN_EXCEPTION, message) {};
-      ForbiddenException(const ForbiddenException& fe) : KuzzleException(fe.status(), fe.getMessage()) {}
+      ForbiddenException(const ForbiddenException& fe) : KuzzleException(fe.status(), fe.what()) {}
   };
   class GatewayTimeoutException: public KuzzleException {
     public:
       GatewayTimeoutException(const std::string& message="Gateway Timeout Exception")
         : KuzzleException(GATEWAY_TIMEOUT_EXCEPTION, message) {};
-      GatewayTimeoutException(const GatewayTimeoutException& gte) : KuzzleException(gte.status(), gte.getMessage()) {}
+      GatewayTimeoutException(const GatewayTimeoutException& gte) : KuzzleException(gte.status(), gte.what()) {}
   };
   class InternalException: public KuzzleException {
     public:
       InternalException(const std::string& message="Internal Exception")
         : KuzzleException(INTERNAL_EXCEPTION, message) {};
-      InternalException(const InternalException& ie) : KuzzleException(ie.status(), ie.getMessage()) {}
+      InternalException(const InternalException& ie) : KuzzleException(ie.status(), ie.what()) {}
   };
   class NotFoundException: public KuzzleException {
     public:
       NotFoundException(const std::string& message="Not Found Exception")
         : KuzzleException(NOT_FOUND_EXCEPTION, message) {};
-      NotFoundException(const NotFoundException& nfe) : KuzzleException(nfe.status(), nfe.getMessage()) {}
+      NotFoundException(const NotFoundException& nfe) : KuzzleException(nfe.status(), nfe.what()) {}
   };
   class PartialException: public KuzzleException {
     public:
       PartialException(const std::string& message="Partial Exception")
         : KuzzleException(PARTIAL_EXCEPTION, message) {};
-      PartialException(const PartialException& pe) : KuzzleException(pe.status(), pe.getMessage()) {}
+      PartialException(const PartialException& pe) : KuzzleException(pe.status(), pe.what()) {}
   };
   class PreconditionException: public KuzzleException {
     public:
       PreconditionException(const std::string& message="Precondition Exception")
         : KuzzleException(PRECONDITION_EXCEPTION, message) {};
-      PreconditionException(const PreconditionException& pe) : KuzzleException(pe.status(), pe.getMessage()) {}
+      PreconditionException(const PreconditionException& pe) : KuzzleException(pe.status(), pe.what()) {}
   };
   class ServiceUnavailableException: public KuzzleException {
     public:
       ServiceUnavailableException(const std::string& message="Service Unavailable Exception")
         : KuzzleException(SERVICE_UNAVAILABLE_EXCEPTION, message) {};
-      ServiceUnavailableException(const ServiceUnavailableException& sue) : KuzzleException(sue.status(), sue.getMessage()) {}
+      ServiceUnavailableException(const ServiceUnavailableException& sue) : KuzzleException(sue.status(), sue.what()) {}
   };
   class SizeLimitException: public KuzzleException {
     public:
       SizeLimitException(const std::string& message="Size Limit Exception")
         : KuzzleException(SIZE_LIMIT_EXCEPTION, message) {};
-      SizeLimitException(const SizeLimitException& sle) : KuzzleException(sle.status(), sle.getMessage()) {}
+      SizeLimitException(const SizeLimitException& sle) : KuzzleException(sle.status(), sle.what()) {}
   };
   class UnauthorizedException : public KuzzleException {
     public:
       UnauthorizedException(const std::string& message="Unauthorized Exception")
       : KuzzleException(UNAUTHORIZED_EXCEPTION, message) {}
-      UnauthorizedException(const UnauthorizedException& ue) : KuzzleException(ue.status(), ue.getMessage()) {}
+      UnauthorizedException(const UnauthorizedException& ue) : KuzzleException(ue.status(), ue.what()) {}
   };
 
   static void throwKuzzleException(int status, const std::string& error) {

--- a/include/internal/exceptions.hpp
+++ b/include/internal/exceptions.hpp
@@ -33,67 +33,95 @@
 
 namespace kuzzleio {
 
-  struct KuzzleException : std::runtime_error {
-    int status;
+  class KuzzleException : public std::runtime_error {
+    private:
+      const int _status;
 
-    KuzzleException(int status, const std::string& message);
-    KuzzleException(const std::string& message)
-    : KuzzleException(500, message) {};
-    KuzzleException(const KuzzleException& ke) : status(ke.status), std::runtime_error(ke.getMessage()) {};
+    public:
+      KuzzleException(const std::string& message)
+        : KuzzleException(500, message)
+        {};
 
-    virtual ~KuzzleException() throw() {};
-    std::string getMessage() const;
+      KuzzleException(int status, const std::string& error)
+        : std::runtime_error(error),
+          _status(status)
+        {};
+
+      KuzzleException(const KuzzleException& ke)
+      : _status(ke.status()),
+        std::runtime_error(ke.message()) {};
+
+      virtual ~KuzzleException() throw() {};
+
+      std::string message() const {
+        return what();
+      };
+
+      int status() const {
+        return _status;
+      };
+
   };
 
-  struct BadRequestException : KuzzleException {
-    BadRequestException(const std::string& message="Bad Request Exception")
-      : KuzzleException(BAD_REQUEST_EXCEPTION, message) {};
-    BadRequestException(const BadRequestException& bre) : KuzzleException(bre.status, bre.getMessage()) {}
+  class BadRequestException : public KuzzleException {
+    public:
+      BadRequestException(const std::string& message="Bad Request Exception")
+        : KuzzleException(BAD_REQUEST_EXCEPTION, message) {};
+      BadRequestException(const BadRequestException& bre) : KuzzleException(bre.status(), bre.message()) {}
   };
-  struct ForbiddenException: KuzzleException {
-    ForbiddenException(const std::string& message="Forbidden Exception")
-      : KuzzleException(FORBIDDEN_EXCEPTION, message) {};
-    ForbiddenException(const ForbiddenException& fe) : KuzzleException(fe.status, fe.getMessage()) {}
+  class ForbiddenException: public KuzzleException {
+    public:
+      ForbiddenException(const std::string& message="Forbidden Exception")
+        : KuzzleException(FORBIDDEN_EXCEPTION, message) {};
+      ForbiddenException(const ForbiddenException& fe) : KuzzleException(fe.status(), fe.message()) {}
   };
-  struct GatewayTimeoutException: KuzzleException {
-    GatewayTimeoutException(const std::string& message="Gateway Timeout Exception")
-      : KuzzleException(GATEWAY_TIMEOUT_EXCEPTION, message) {};
-    GatewayTimeoutException(const GatewayTimeoutException& gte) : KuzzleException(gte.status, gte.getMessage()) {}
+  class GatewayTimeoutException: public KuzzleException {
+    public:
+      GatewayTimeoutException(const std::string& message="Gateway Timeout Exception")
+        : KuzzleException(GATEWAY_TIMEOUT_EXCEPTION, message) {};
+      GatewayTimeoutException(const GatewayTimeoutException& gte) : KuzzleException(gte.status(), gte.message()) {}
   };
-  struct InternalException: KuzzleException {
-    InternalException(const std::string& message="Internal Exception")
-      : KuzzleException(INTERNAL_EXCEPTION, message) {};
-    InternalException(const InternalException& ie) : KuzzleException(ie.status, ie.getMessage()) {}
+  class InternalException: public KuzzleException {
+    public:
+      InternalException(const std::string& message="Internal Exception")
+        : KuzzleException(INTERNAL_EXCEPTION, message) {};
+      InternalException(const InternalException& ie) : KuzzleException(ie.status(), ie.message()) {}
   };
-  struct NotFoundException: KuzzleException {
-    NotFoundException(const std::string& message="Not Found Exception")
-      : KuzzleException(NOT_FOUND_EXCEPTION, message) {};
-    NotFoundException(const NotFoundException& nfe) : KuzzleException(nfe.status, nfe.getMessage()) {}
+  class NotFoundException: public KuzzleException {
+    public:
+      NotFoundException(const std::string& message="Not Found Exception")
+        : KuzzleException(NOT_FOUND_EXCEPTION, message) {};
+      NotFoundException(const NotFoundException& nfe) : KuzzleException(nfe.status(), nfe.message()) {}
   };
-  struct PartialException: KuzzleException {
-    PartialException(const std::string& message="Partial Exception")
-      : KuzzleException(PARTIAL_EXCEPTION, message) {};
-    PartialException(const PartialException& pe) : KuzzleException(pe.status, pe.getMessage()) {}
+  class PartialException: public KuzzleException {
+    public:
+      PartialException(const std::string& message="Partial Exception")
+        : KuzzleException(PARTIAL_EXCEPTION, message) {};
+      PartialException(const PartialException& pe) : KuzzleException(pe.status(), pe.message()) {}
   };
-  struct PreconditionException: KuzzleException {
-    PreconditionException(const std::string& message="Precondition Exception")
-      : KuzzleException(PRECONDITION_EXCEPTION, message) {};
-    PreconditionException(const PreconditionException& pe) : KuzzleException(pe.status, pe.getMessage()) {}
+  class PreconditionException: public KuzzleException {
+    public:
+      PreconditionException(const std::string& message="Precondition Exception")
+        : KuzzleException(PRECONDITION_EXCEPTION, message) {};
+      PreconditionException(const PreconditionException& pe) : KuzzleException(pe.status(), pe.message()) {}
   };
-  struct ServiceUnavailableException: KuzzleException {
-    ServiceUnavailableException(const std::string& message="Service Unavailable Exception")
-      : KuzzleException(SERVICE_UNAVAILABLE_EXCEPTION, message) {};
-    ServiceUnavailableException(const ServiceUnavailableException& sue) : KuzzleException(sue.status, sue.getMessage()) {}
+  class ServiceUnavailableException: public KuzzleException {
+    public:
+      ServiceUnavailableException(const std::string& message="Service Unavailable Exception")
+        : KuzzleException(SERVICE_UNAVAILABLE_EXCEPTION, message) {};
+      ServiceUnavailableException(const ServiceUnavailableException& sue) : KuzzleException(sue.status(), sue.message()) {}
   };
-  struct SizeLimitException: KuzzleException {
-    SizeLimitException(const std::string& message="Size Limit Exception")
-      : KuzzleException(SIZE_LIMIT_EXCEPTION, message) {};
-    SizeLimitException(const SizeLimitException& sle) : KuzzleException(sle.status, sle.getMessage()) {}
+  class SizeLimitException: public KuzzleException {
+    public:
+      SizeLimitException(const std::string& message="Size Limit Exception")
+        : KuzzleException(SIZE_LIMIT_EXCEPTION, message) {};
+      SizeLimitException(const SizeLimitException& sle) : KuzzleException(sle.status(), sle.message()) {}
   };
-  struct UnauthorizedException : KuzzleException {
-    UnauthorizedException(const std::string& message="Unauthorized Exception")
-     : KuzzleException(UNAUTHORIZED_EXCEPTION, message) {}
-    UnauthorizedException(const UnauthorizedException& ue) : KuzzleException(ue.status, ue.getMessage()) {}
+  class UnauthorizedException : public KuzzleException {
+    public:
+      UnauthorizedException(const std::string& message="Unauthorized Exception")
+      : KuzzleException(UNAUTHORIZED_EXCEPTION, message) {}
+      UnauthorizedException(const UnauthorizedException& ue) : KuzzleException(ue.status(), ue.message()) {}
   };
 
   static void throwKuzzleException(int status, const std::string& error) {

--- a/include/internal/exceptions.hpp
+++ b/include/internal/exceptions.hpp
@@ -35,6 +35,7 @@ namespace kuzzleio {
 
   class KuzzleException : public std::runtime_error {
     private:
+      const std::string _message;
       const int _status;
 
     public:
@@ -49,11 +50,11 @@ namespace kuzzleio {
 
       KuzzleException(const KuzzleException& ke)
       : _status(ke.status()),
-        std::runtime_error(ke.message()) {};
+        std::runtime_error(ke.getMessage()) {};
 
       virtual ~KuzzleException() throw() {};
 
-      std::string message() const {
+      std::string getMessage() const {
         return what();
       };
 
@@ -67,61 +68,61 @@ namespace kuzzleio {
     public:
       BadRequestException(const std::string& message="Bad Request Exception")
         : KuzzleException(BAD_REQUEST_EXCEPTION, message) {};
-      BadRequestException(const BadRequestException& bre) : KuzzleException(bre.status(), bre.message()) {}
+      BadRequestException(const BadRequestException& bre) : KuzzleException(bre.status(), bre.getMessage()) {}
   };
   class ForbiddenException: public KuzzleException {
     public:
       ForbiddenException(const std::string& message="Forbidden Exception")
         : KuzzleException(FORBIDDEN_EXCEPTION, message) {};
-      ForbiddenException(const ForbiddenException& fe) : KuzzleException(fe.status(), fe.message()) {}
+      ForbiddenException(const ForbiddenException& fe) : KuzzleException(fe.status(), fe.getMessage()) {}
   };
   class GatewayTimeoutException: public KuzzleException {
     public:
       GatewayTimeoutException(const std::string& message="Gateway Timeout Exception")
         : KuzzleException(GATEWAY_TIMEOUT_EXCEPTION, message) {};
-      GatewayTimeoutException(const GatewayTimeoutException& gte) : KuzzleException(gte.status(), gte.message()) {}
+      GatewayTimeoutException(const GatewayTimeoutException& gte) : KuzzleException(gte.status(), gte.getMessage()) {}
   };
   class InternalException: public KuzzleException {
     public:
       InternalException(const std::string& message="Internal Exception")
         : KuzzleException(INTERNAL_EXCEPTION, message) {};
-      InternalException(const InternalException& ie) : KuzzleException(ie.status(), ie.message()) {}
+      InternalException(const InternalException& ie) : KuzzleException(ie.status(), ie.getMessage()) {}
   };
   class NotFoundException: public KuzzleException {
     public:
       NotFoundException(const std::string& message="Not Found Exception")
         : KuzzleException(NOT_FOUND_EXCEPTION, message) {};
-      NotFoundException(const NotFoundException& nfe) : KuzzleException(nfe.status(), nfe.message()) {}
+      NotFoundException(const NotFoundException& nfe) : KuzzleException(nfe.status(), nfe.getMessage()) {}
   };
   class PartialException: public KuzzleException {
     public:
       PartialException(const std::string& message="Partial Exception")
         : KuzzleException(PARTIAL_EXCEPTION, message) {};
-      PartialException(const PartialException& pe) : KuzzleException(pe.status(), pe.message()) {}
+      PartialException(const PartialException& pe) : KuzzleException(pe.status(), pe.getMessage()) {}
   };
   class PreconditionException: public KuzzleException {
     public:
       PreconditionException(const std::string& message="Precondition Exception")
         : KuzzleException(PRECONDITION_EXCEPTION, message) {};
-      PreconditionException(const PreconditionException& pe) : KuzzleException(pe.status(), pe.message()) {}
+      PreconditionException(const PreconditionException& pe) : KuzzleException(pe.status(), pe.getMessage()) {}
   };
   class ServiceUnavailableException: public KuzzleException {
     public:
       ServiceUnavailableException(const std::string& message="Service Unavailable Exception")
         : KuzzleException(SERVICE_UNAVAILABLE_EXCEPTION, message) {};
-      ServiceUnavailableException(const ServiceUnavailableException& sue) : KuzzleException(sue.status(), sue.message()) {}
+      ServiceUnavailableException(const ServiceUnavailableException& sue) : KuzzleException(sue.status(), sue.getMessage()) {}
   };
   class SizeLimitException: public KuzzleException {
     public:
       SizeLimitException(const std::string& message="Size Limit Exception")
         : KuzzleException(SIZE_LIMIT_EXCEPTION, message) {};
-      SizeLimitException(const SizeLimitException& sle) : KuzzleException(sle.status(), sle.message()) {}
+      SizeLimitException(const SizeLimitException& sle) : KuzzleException(sle.status(), sle.getMessage()) {}
   };
   class UnauthorizedException : public KuzzleException {
     public:
       UnauthorizedException(const std::string& message="Unauthorized Exception")
       : KuzzleException(UNAUTHORIZED_EXCEPTION, message) {}
-      UnauthorizedException(const UnauthorizedException& ue) : KuzzleException(ue.status(), ue.message()) {}
+      UnauthorizedException(const UnauthorizedException& ue) : KuzzleException(ue.status(), ue.getMessage()) {}
   };
 
   static void throwKuzzleException(int status, const std::string& error) {

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -130,14 +130,6 @@ namespace kuzzleio {
     return static_cast<Protocol*>(data)->getHost().c_str();
   }
 
-  // Class
-  KuzzleException::KuzzleException(int status, const std::string& error)
-    : std::runtime_error(error), status(status) {}
-
-  std::string KuzzleException::getMessage() const {
-    return what();
-  }
-
   Kuzzle::Kuzzle(Protocol* proto) : Kuzzle(proto, options()) {}
 
   Kuzzle::Kuzzle(Protocol* proto, const options& options) {

--- a/test/features/step_definitions/auth-steps.cpp
+++ b/test/features/step_definitions/auth-steps.cpp
@@ -36,7 +36,7 @@ namespace {
       K_LOG_D("Logged in as '%s'", username.c_str());
       K_LOG_D("JWT is: %s", jwt.c_str());
     } catch (KuzzleException e) {
-      K_LOG_W(e.message().c_str());
+      K_LOG_W(e.getMessage().c_str());
     }
     ctx->jwt = jwt;
   }
@@ -81,7 +81,7 @@ namespace {
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
-      K_LOG_E(e.message().c_str());
+      K_LOG_E(e.getMessage().c_str());
     }
   }
 

--- a/test/features/step_definitions/auth-steps.cpp
+++ b/test/features/step_definitions/auth-steps.cpp
@@ -36,7 +36,7 @@ namespace {
       K_LOG_D("Logged in as '%s'", username.c_str());
       K_LOG_D("JWT is: %s", jwt.c_str());
     } catch (KuzzleException e) {
-      K_LOG_W(e.getMessage().c_str());
+      K_LOG_W(e.what().c_str());
     }
     ctx->jwt = jwt;
   }
@@ -81,7 +81,7 @@ namespace {
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.what().c_str());
     }
   }
 

--- a/test/features/step_definitions/auth-steps.cpp
+++ b/test/features/step_definitions/auth-steps.cpp
@@ -36,7 +36,7 @@ namespace {
       K_LOG_D("Logged in as '%s'", username.c_str());
       K_LOG_D("JWT is: %s", jwt.c_str());
     } catch (KuzzleException e) {
-      K_LOG_W(e.getMessage().c_str());
+      K_LOG_W(e.message().c_str());
     }
     ctx->jwt = jwt;
   }
@@ -81,7 +81,7 @@ namespace {
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.message().c_str());
     }
   }
 

--- a/test/features/step_definitions/auth-steps.cpp
+++ b/test/features/step_definitions/auth-steps.cpp
@@ -36,7 +36,7 @@ namespace {
       K_LOG_D("Logged in as '%s'", username.c_str());
       K_LOG_D("JWT is: %s", jwt.c_str());
     } catch (KuzzleException e) {
-      K_LOG_W(e.what().c_str());
+      K_LOG_W(e.what());
     }
     ctx->jwt = jwt;
   }
@@ -81,7 +81,7 @@ namespace {
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
-      K_LOG_E(e.what().c_str());
+      K_LOG_E(e.what());
     }
   }
 

--- a/test/features/step_definitions/collection-steps.cpp
+++ b/test/features/step_definitions/collection-steps.cpp
@@ -52,7 +52,7 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, ctx->collection);
     } catch (KuzzleException e) {
-      K_LOG_E(e.what().c_str());
+      K_LOG_E(e.what());
       BOOST_FAIL(e.what());
     }
   }

--- a/test/features/step_definitions/collection-steps.cpp
+++ b/test/features/step_definitions/collection-steps.cpp
@@ -12,7 +12,7 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -52,8 +52,8 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, ctx->collection);
     } catch (KuzzleException e) {
-      K_LOG_E(e.message().c_str());
-      BOOST_FAIL(e.message());
+      K_LOG_E(e.getMessage().c_str());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -211,7 +211,7 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id, mapping);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 }

--- a/test/features/step_definitions/collection-steps.cpp
+++ b/test/features/step_definitions/collection-steps.cpp
@@ -12,7 +12,7 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -52,8 +52,8 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, ctx->collection);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
-      BOOST_FAIL(e.getMessage());
+      K_LOG_E(e.message().c_str());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -211,7 +211,7 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id, mapping);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 }

--- a/test/features/step_definitions/collection-steps.cpp
+++ b/test/features/step_definitions/collection-steps.cpp
@@ -12,7 +12,7 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -52,8 +52,8 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, ctx->collection);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
-      BOOST_FAIL(e.getMessage());
+      K_LOG_E(e.what().c_str());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -211,7 +211,7 @@ namespace {
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id, mapping);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 }

--- a/test/features/step_definitions/document-steps.cpp
+++ b/test/features/step_definitions/document-steps.cpp
@@ -16,7 +16,7 @@ namespace {
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
-      ctx->error_message = e.getMessage();
+      ctx->error_message = e.message();
     }
   }
 
@@ -48,7 +48,7 @@ namespace {
 
       ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id, options);
     } catch (KuzzleException e) {
-      ctx->error_message = e.getMessage();
+      ctx->error_message = e.message();
       ctx->success = 0;
     }
   }
@@ -66,7 +66,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -94,7 +94,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -119,7 +119,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -143,7 +143,7 @@ namespace {
       ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, "{\"query\": {\"bool\": {\"should\":[{\"match\":{\"_id\": \"" + document_id + "\"}}]}}}");
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -162,7 +162,7 @@ namespace {
 
       ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, query, options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -173,7 +173,7 @@ namespace {
     try {
       ctx->documents = ctx->documents->next();
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -198,7 +198,7 @@ namespace {
     try {
       ctx->hits = ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}");
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -224,7 +224,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -237,7 +237,7 @@ namespace {
     try {
       BOOST_CHECK(ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}") == documents_count);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -260,7 +260,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -283,7 +283,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -317,7 +317,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -351,7 +351,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 

--- a/test/features/step_definitions/document-steps.cpp
+++ b/test/features/step_definitions/document-steps.cpp
@@ -16,7 +16,7 @@ namespace {
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
-      ctx->error_message = e.message();
+      ctx->error_message = e.getMessage();
     }
   }
 
@@ -48,7 +48,7 @@ namespace {
 
       ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id, options);
     } catch (KuzzleException e) {
-      ctx->error_message = e.message();
+      ctx->error_message = e.getMessage();
       ctx->success = 0;
     }
   }
@@ -66,7 +66,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -94,7 +94,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -119,7 +119,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -143,7 +143,7 @@ namespace {
       ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, "{\"query\": {\"bool\": {\"should\":[{\"match\":{\"_id\": \"" + document_id + "\"}}]}}}");
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -162,7 +162,7 @@ namespace {
 
       ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, query, options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -173,7 +173,7 @@ namespace {
     try {
       ctx->documents = ctx->documents->next();
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -198,7 +198,7 @@ namespace {
     try {
       ctx->hits = ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}");
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -224,7 +224,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -237,7 +237,7 @@ namespace {
     try {
       BOOST_CHECK(ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}") == documents_count);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -260,7 +260,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -283,7 +283,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -317,7 +317,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -351,7 +351,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 

--- a/test/features/step_definitions/document-steps.cpp
+++ b/test/features/step_definitions/document-steps.cpp
@@ -16,7 +16,7 @@ namespace {
       ctx->success = 1;
     } catch (KuzzleException e) {
       ctx->success = 0;
-      ctx->error_message = e.getMessage();
+      ctx->error_message = e.what();
     }
   }
 
@@ -48,7 +48,7 @@ namespace {
 
       ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id, options);
     } catch (KuzzleException e) {
-      ctx->error_message = e.getMessage();
+      ctx->error_message = e.what();
       ctx->success = 0;
     }
   }
@@ -66,7 +66,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -94,7 +94,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -119,7 +119,7 @@ namespace {
       ctx->document_id = document_id;
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -143,7 +143,7 @@ namespace {
       ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, "{\"query\": {\"bool\": {\"should\":[{\"match\":{\"_id\": \"" + document_id + "\"}}]}}}");
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -162,7 +162,7 @@ namespace {
 
       ctx->documents = ctx->kuzzle->document->search(ctx->index, ctx->collection, query, options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -173,7 +173,7 @@ namespace {
     try {
       ctx->documents = ctx->documents->next();
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -198,7 +198,7 @@ namespace {
     try {
       ctx->hits = ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}");
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -224,7 +224,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -237,7 +237,7 @@ namespace {
     try {
       BOOST_CHECK(ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}") == documents_count);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -260,7 +260,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -283,7 +283,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -317,7 +317,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -351,7 +351,7 @@ namespace {
       ctx->partial_exception = 1;
       ctx->success = 0;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 

--- a/test/features/step_definitions/index-steps.cpp
+++ b/test/features/step_definitions/index-steps.cpp
@@ -12,8 +12,8 @@ namespace {
     try {
       ctx->kuzzle->index->delete_(index_name);
     } catch (KuzzleException e) {
-      K_LOG_E(e.message().c_str());
-      BOOST_FAIL(e.message());
+      K_LOG_E(e.getMessage().c_str());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -28,8 +28,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name);
       } catch (KuzzleException e) {
-        K_LOG_E(e.message().c_str());
-        BOOST_FAIL(e.message());
+        K_LOG_E(e.getMessage().c_str());
+        BOOST_FAIL(e.getMessage());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name.c_str());
@@ -46,8 +46,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name1);
       } catch(KuzzleException e) {
-        K_LOG_E(e.message().c_str());
-        BOOST_FAIL(e.message());
+        K_LOG_E(e.getMessage().c_str());
+        BOOST_FAIL(e.getMessage());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name1.c_str());
@@ -57,8 +57,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name2);
       } catch(KuzzleException e) {
-        K_LOG_E(e.message().c_str());
-        BOOST_FAIL(e.message());
+        K_LOG_E(e.getMessage().c_str());
+        BOOST_FAIL(e.getMessage());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name2.c_str());
@@ -79,8 +79,8 @@ namespace {
     try {
       ctx->kuzzle->index->mDelete(v);
     } catch(KuzzleException e) {
-      K_LOG_E(e.message().c_str());
-      BOOST_FAIL(e.message());
+      K_LOG_E(e.getMessage().c_str());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -96,7 +96,7 @@ namespace {
       ctx->index = index_name;
     } catch (KuzzleException e) {
       ctx->success = false;
-      K_LOG_E(e.message().c_str());
+      K_LOG_E(e.getMessage().c_str());
     }
   }
 

--- a/test/features/step_definitions/index-steps.cpp
+++ b/test/features/step_definitions/index-steps.cpp
@@ -12,8 +12,8 @@ namespace {
     try {
       ctx->kuzzle->index->delete_(index_name);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
-      BOOST_FAIL(e.getMessage());
+      K_LOG_E(e.what().c_str());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -28,8 +28,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name);
       } catch (KuzzleException e) {
-        K_LOG_E(e.getMessage().c_str());
-        BOOST_FAIL(e.getMessage());
+        K_LOG_E(e.what().c_str());
+        BOOST_FAIL(e.what());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name.c_str());
@@ -46,8 +46,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name1);
       } catch(KuzzleException e) {
-        K_LOG_E(e.getMessage().c_str());
-        BOOST_FAIL(e.getMessage());
+        K_LOG_E(e.what().c_str());
+        BOOST_FAIL(e.what());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name1.c_str());
@@ -57,8 +57,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name2);
       } catch(KuzzleException e) {
-        K_LOG_E(e.getMessage().c_str());
-        BOOST_FAIL(e.getMessage());
+        K_LOG_E(e.what().c_str());
+        BOOST_FAIL(e.what());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name2.c_str());
@@ -79,8 +79,8 @@ namespace {
     try {
       ctx->kuzzle->index->mDelete(v);
     } catch(KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
-      BOOST_FAIL(e.getMessage());
+      K_LOG_E(e.what().c_str());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -96,7 +96,7 @@ namespace {
       ctx->index = index_name;
     } catch (KuzzleException e) {
       ctx->success = false;
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.what().c_str());
     }
   }
 

--- a/test/features/step_definitions/index-steps.cpp
+++ b/test/features/step_definitions/index-steps.cpp
@@ -12,8 +12,8 @@ namespace {
     try {
       ctx->kuzzle->index->delete_(index_name);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
-      BOOST_FAIL(e.getMessage());
+      K_LOG_E(e.message().c_str());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -28,8 +28,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name);
       } catch (KuzzleException e) {
-        K_LOG_E(e.getMessage().c_str());
-        BOOST_FAIL(e.getMessage());
+        K_LOG_E(e.message().c_str());
+        BOOST_FAIL(e.message());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name.c_str());
@@ -46,8 +46,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name1);
       } catch(KuzzleException e) {
-        K_LOG_E(e.getMessage().c_str());
-        BOOST_FAIL(e.getMessage());
+        K_LOG_E(e.message().c_str());
+        BOOST_FAIL(e.message());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name1.c_str());
@@ -57,8 +57,8 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name2);
       } catch(KuzzleException e) {
-        K_LOG_E(e.getMessage().c_str());
-        BOOST_FAIL(e.getMessage());
+        K_LOG_E(e.message().c_str());
+        BOOST_FAIL(e.message());
       }
     } else {
       K_LOG_D("Using existing index: %s", index_name2.c_str());
@@ -79,8 +79,8 @@ namespace {
     try {
       ctx->kuzzle->index->mDelete(v);
     } catch(KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
-      BOOST_FAIL(e.getMessage());
+      K_LOG_E(e.message().c_str());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -96,7 +96,7 @@ namespace {
       ctx->index = index_name;
     } catch (KuzzleException e) {
       ctx->success = false;
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.message().c_str());
     }
   }
 

--- a/test/features/step_definitions/index-steps.cpp
+++ b/test/features/step_definitions/index-steps.cpp
@@ -12,7 +12,7 @@ namespace {
     try {
       ctx->kuzzle->index->delete_(index_name);
     } catch (KuzzleException e) {
-      K_LOG_E(e.what().c_str());
+      K_LOG_E(e.what());
       BOOST_FAIL(e.what());
     }
   }
@@ -28,7 +28,7 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name);
       } catch (KuzzleException e) {
-        K_LOG_E(e.what().c_str());
+        K_LOG_E(e.what());
         BOOST_FAIL(e.what());
       }
     } else {
@@ -46,7 +46,7 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name1);
       } catch(KuzzleException e) {
-        K_LOG_E(e.what().c_str());
+        K_LOG_E(e.what());
         BOOST_FAIL(e.what());
       }
     } else {
@@ -57,7 +57,7 @@ namespace {
       try {
         ctx->kuzzle->index->create(index_name2);
       } catch(KuzzleException e) {
-        K_LOG_E(e.what().c_str());
+        K_LOG_E(e.what());
         BOOST_FAIL(e.what());
       }
     } else {
@@ -79,7 +79,7 @@ namespace {
     try {
       ctx->kuzzle->index->mDelete(v);
     } catch(KuzzleException e) {
-      K_LOG_E(e.what().c_str());
+      K_LOG_E(e.what());
       BOOST_FAIL(e.what());
     }
   }
@@ -96,7 +96,7 @@ namespace {
       ctx->index = index_name;
     } catch (KuzzleException e) {
       ctx->success = false;
-      K_LOG_E(e.what().c_str());
+      K_LOG_E(e.what());
     }
   }
 

--- a/test/features/step_definitions/kuzzle-sdk-steps.cpp
+++ b/test/features/step_definitions/kuzzle-sdk-steps.cpp
@@ -19,7 +19,7 @@ namespace {
     try {
       ctx->kuzzle->auth->updateSelf(data);
     } catch (KuzzleException e) {
-      K_LOG_E(e.message().c_str());
+      K_LOG_E(e.getMessage().c_str());
     }
   }
 
@@ -104,7 +104,7 @@ namespace {
       ctx->protocol = new WebSocket(hostname);
       ctx->kuzzle = new Kuzzle(ctx->protocol, ctx->kuzzle_options);
     } catch (KuzzleException e) {
-      K_LOG_E(e.message().c_str());
+      K_LOG_E(e.getMessage().c_str());
     }
 
     // throws if it fails to connect

--- a/test/features/step_definitions/kuzzle-sdk-steps.cpp
+++ b/test/features/step_definitions/kuzzle-sdk-steps.cpp
@@ -19,7 +19,7 @@ namespace {
     try {
       ctx->kuzzle->auth->updateSelf(data);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.message().c_str());
     }
   }
 
@@ -104,7 +104,7 @@ namespace {
       ctx->protocol = new WebSocket(hostname);
       ctx->kuzzle = new Kuzzle(ctx->protocol, ctx->kuzzle_options);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.message().c_str());
     }
 
     // throws if it fails to connect

--- a/test/features/step_definitions/kuzzle-sdk-steps.cpp
+++ b/test/features/step_definitions/kuzzle-sdk-steps.cpp
@@ -19,7 +19,7 @@ namespace {
     try {
       ctx->kuzzle->auth->updateSelf(data);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.what().c_str());
     }
   }
 
@@ -104,7 +104,7 @@ namespace {
       ctx->protocol = new WebSocket(hostname);
       ctx->kuzzle = new Kuzzle(ctx->protocol, ctx->kuzzle_options);
     } catch (KuzzleException e) {
-      K_LOG_E(e.getMessage().c_str());
+      K_LOG_E(e.what().c_str());
     }
 
     // throws if it fails to connect

--- a/test/features/step_definitions/kuzzle-sdk-steps.cpp
+++ b/test/features/step_definitions/kuzzle-sdk-steps.cpp
@@ -19,7 +19,7 @@ namespace {
     try {
       ctx->kuzzle->auth->updateSelf(data);
     } catch (KuzzleException e) {
-      K_LOG_E(e.what().c_str());
+      K_LOG_E(e.what());
     }
   }
 
@@ -104,7 +104,7 @@ namespace {
       ctx->protocol = new WebSocket(hostname);
       ctx->kuzzle = new Kuzzle(ctx->protocol, ctx->kuzzle_options);
     } catch (KuzzleException e) {
-      K_LOG_E(e.what().c_str());
+      K_LOG_E(e.what());
     }
 
     // throws if it fails to connect

--- a/test/features/step_definitions/kuzzle_utils.cpp
+++ b/test/features/step_definitions/kuzzle_utils.cpp
@@ -83,7 +83,7 @@ bool kuzzle_user_exists(Kuzzle *kuzzle, const string &user_id)
   }
   catch (KuzzleException e)
   {
-    K_LOG_W(e.message().c_str());
+    K_LOG_W(e.getMessage().c_str());
   }
   return user_exists;
 }
@@ -131,7 +131,7 @@ void kuzzle_credentials_delete(Kuzzle *kuzzle, const string &strategy,
   {
     K_LOG_E("Failed to delete '%s' credentials for userId '%s'",
             strategy.c_str(), user_id.c_str());
-    K_LOG_E(e.message().c_str());
+    K_LOG_E(e.getMessage().c_str());
   }
 }
 
@@ -167,7 +167,7 @@ void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
   }
   catch (KuzzleException e)
   {
-    K_LOG_E("Status (%d): %s", e.status, e.message().c_str());
+    K_LOG_E("Status (%d): %s", e.status, e.getMessage().c_str());
     if (kuzzle_user_exists(kuzzle, user_id.c_str())) {
       K_LOG_W("But user seems to exist anyway?????");
     }

--- a/test/features/step_definitions/kuzzle_utils.cpp
+++ b/test/features/step_definitions/kuzzle_utils.cpp
@@ -83,7 +83,7 @@ bool kuzzle_user_exists(Kuzzle *kuzzle, const string &user_id)
   }
   catch (KuzzleException e)
   {
-    K_LOG_W(e.getMessage().c_str());
+    K_LOG_W(e.what().c_str());
   }
   return user_exists;
 }
@@ -131,7 +131,7 @@ void kuzzle_credentials_delete(Kuzzle *kuzzle, const string &strategy,
   {
     K_LOG_E("Failed to delete '%s' credentials for userId '%s'",
             strategy.c_str(), user_id.c_str());
-    K_LOG_E(e.getMessage().c_str());
+    K_LOG_E(e.what().c_str());
   }
 }
 
@@ -167,7 +167,7 @@ void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
   }
   catch (KuzzleException e)
   {
-    K_LOG_E("Status (%d): %s", e.status, e.getMessage().c_str());
+    K_LOG_E("Status (%d): %s", e.status(), e.what().c_str());
     if (kuzzle_user_exists(kuzzle, user_id.c_str())) {
       K_LOG_W("But user seems to exist anyway?????");
     }

--- a/test/features/step_definitions/kuzzle_utils.cpp
+++ b/test/features/step_definitions/kuzzle_utils.cpp
@@ -83,7 +83,7 @@ bool kuzzle_user_exists(Kuzzle *kuzzle, const string &user_id)
   }
   catch (KuzzleException e)
   {
-    K_LOG_W(e.what().c_str());
+    K_LOG_W(e.what());
   }
   return user_exists;
 }
@@ -131,7 +131,7 @@ void kuzzle_credentials_delete(Kuzzle *kuzzle, const string &strategy,
   {
     K_LOG_E("Failed to delete '%s' credentials for userId '%s'",
             strategy.c_str(), user_id.c_str());
-    K_LOG_E(e.what().c_str());
+    K_LOG_E(e.what());
   }
 }
 
@@ -167,7 +167,7 @@ void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
   }
   catch (KuzzleException e)
   {
-    K_LOG_E("Status (%d): %s", e.status(), e.what().c_str());
+    K_LOG_E("Status (%d): %s", e.status(), e.what());
     if (kuzzle_user_exists(kuzzle, user_id.c_str())) {
       K_LOG_W("But user seems to exist anyway?????");
     }

--- a/test/features/step_definitions/kuzzle_utils.cpp
+++ b/test/features/step_definitions/kuzzle_utils.cpp
@@ -83,7 +83,7 @@ bool kuzzle_user_exists(Kuzzle *kuzzle, const string &user_id)
   }
   catch (KuzzleException e)
   {
-    K_LOG_W(e.getMessage().c_str());
+    K_LOG_W(e.message().c_str());
   }
   return user_exists;
 }
@@ -131,7 +131,7 @@ void kuzzle_credentials_delete(Kuzzle *kuzzle, const string &strategy,
   {
     K_LOG_E("Failed to delete '%s' credentials for userId '%s'",
             strategy.c_str(), user_id.c_str());
-    K_LOG_E(e.getMessage().c_str());
+    K_LOG_E(e.message().c_str());
   }
 }
 
@@ -167,7 +167,7 @@ void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
   }
   catch (KuzzleException e)
   {
-    K_LOG_E("Status (%d): %s", e.status, e.getMessage().c_str());
+    K_LOG_E("Status (%d): %s", e.status, e.message().c_str());
     if (kuzzle_user_exists(kuzzle, user_id.c_str())) {
       K_LOG_W("But user seems to exist anyway?????");
     }

--- a/test/features/step_definitions/realtime-steps.cpp
+++ b/test/features/step_definitions/realtime-steps.cpp
@@ -17,7 +17,7 @@ namespace {
       CustomNotificationListener *l = CustomNotificationListener::getSingleton();
       ctx->room_id = ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, "{}", &l->listener);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -32,7 +32,7 @@ namespace {
     try {
       ctx->kuzzle->document->create(ctx->index, ctx->collection, "", R"({"foo":"bar"})", options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -57,7 +57,7 @@ namespace {
       CustomNotificationListener *l = CustomNotificationListener::getSingleton();
       ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, filter, &l->listener);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -74,7 +74,7 @@ namespace {
     try {
       ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\""+key+"\":\""+value+"\"}", options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -87,7 +87,7 @@ namespace {
       ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id);
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -97,7 +97,7 @@ namespace {
     try {
       ctx->kuzzle->realtime->publish(ctx->index, ctx->collection, "{}");
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 
@@ -108,7 +108,7 @@ namespace {
       ctx->kuzzle->realtime->unsubscribe(ctx->room_id);
       ctx->notif_result = NULL;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.what());
     }
   }
 

--- a/test/features/step_definitions/realtime-steps.cpp
+++ b/test/features/step_definitions/realtime-steps.cpp
@@ -17,7 +17,7 @@ namespace {
       CustomNotificationListener *l = CustomNotificationListener::getSingleton();
       ctx->room_id = ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, "{}", &l->listener);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -32,7 +32,7 @@ namespace {
     try {
       ctx->kuzzle->document->create(ctx->index, ctx->collection, "", R"({"foo":"bar"})", options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -57,7 +57,7 @@ namespace {
       CustomNotificationListener *l = CustomNotificationListener::getSingleton();
       ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, filter, &l->listener);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -74,7 +74,7 @@ namespace {
     try {
       ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\""+key+"\":\""+value+"\"}", options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -87,7 +87,7 @@ namespace {
       ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id);
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -97,7 +97,7 @@ namespace {
     try {
       ctx->kuzzle->realtime->publish(ctx->index, ctx->collection, "{}");
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 
@@ -108,7 +108,7 @@ namespace {
       ctx->kuzzle->realtime->unsubscribe(ctx->room_id);
       ctx->notif_result = NULL;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.getMessage());
+      BOOST_FAIL(e.message());
     }
   }
 

--- a/test/features/step_definitions/realtime-steps.cpp
+++ b/test/features/step_definitions/realtime-steps.cpp
@@ -17,7 +17,7 @@ namespace {
       CustomNotificationListener *l = CustomNotificationListener::getSingleton();
       ctx->room_id = ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, "{}", &l->listener);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -32,7 +32,7 @@ namespace {
     try {
       ctx->kuzzle->document->create(ctx->index, ctx->collection, "", R"({"foo":"bar"})", options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -57,7 +57,7 @@ namespace {
       CustomNotificationListener *l = CustomNotificationListener::getSingleton();
       ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, filter, &l->listener);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -74,7 +74,7 @@ namespace {
     try {
       ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\""+key+"\":\""+value+"\"}", options);
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -87,7 +87,7 @@ namespace {
       ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id);
       ctx->success = 1;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -97,7 +97,7 @@ namespace {
     try {
       ctx->kuzzle->realtime->publish(ctx->index, ctx->collection, "{}");
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 
@@ -108,7 +108,7 @@ namespace {
       ctx->kuzzle->realtime->unsubscribe(ctx->room_id);
       ctx->notif_result = NULL;
     } catch (KuzzleException e) {
-      BOOST_FAIL(e.message());
+      BOOST_FAIL(e.getMessage());
     }
   }
 


### PR DESCRIPTION
## What does this PR do ?

Adds a `status()` getter for exceptions so we can use them in sdks generated by SWIG (c# for example)

### Other changes

 - Declare everything in header and use `class` keyword