### PR TITLE
Fix non implemented methods search result

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ You can use this Docker image to build the SDK:
 docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make clean all
 ```
 
+### Build with MSVC
+
+MSVC does not support linking with DLLs, you must use the workaround described here: https://stackoverflow.com/questions/9946322/how-to-generate-an-import-library-lib-file-from-a-dll
+
+In addition, you must also use the `-buildmode=c-shared` compilation option for the SDK to work properly.
+
 ## Compile with the SDK
 
 Use this commande to compile a cpp source file with the builded SDK:


### PR DESCRIPTION
## What does this PR do ?

There is missing implementation on the search_result class.

```
/mnt/build/android/app/src/main/obj/local/arm64-v8a/objs/kuzzle/__/__/__/__/__/__/kcore_wrap.o: In function `Java_io_kuzzle_sdk_kuzzlesdkJNI_new_1SpecificationSearchResult':
/mnt/build/android/app/src/main/jni/../../../../../../kcore_wrap.cxx:81434: undefined reference to `kuzzleio::SpecificationSearchResult::SpecificationSearchResult(kuzzleio::search_result const*)'
/mnt/build/android/app/src/main/obj/local/arm64-v8a/objs/kuzzle/__/__/__/__/__/__/kcore_wrap.o: In function `Java_io_kuzzle_sdk_kuzzlesdkJNI_SpecificationSearchResult_1next':
/mnt/build/android/app/src/main/jni/../../../../../../kcore_wrap.cxx:81619: undefined reference to `kuzzleio::SpecificationSearchResult::next() const'
```