### PR TITLE
Fix CGo Deadlock

### DIFF
--- a/include/internal/options.hpp
+++ b/include/internal/options.hpp
@@ -17,23 +17,19 @@
 
 #include "internal/core.hpp"
 #include <string>
-#include <unordered_map>
 
 namespace kuzzleio {
   class Options {
     private:
       options *c_options;
-      std::unordered_map<std::string, std::string> headers;
-      bool headers_changed;
-
-      void resyncHeaders();
+      size_t header_capacity;
 
     public:
       Options();
       virtual ~Options();
 
       // getters
-      options* c_opts() noexcept;
+      options* c_opts() const noexcept;
       bool autoQueue() const noexcept;
       bool autoReconnect() const noexcept;
       bool autoReplay() const noexcept;
@@ -58,12 +54,11 @@ namespace kuzzleio {
       void sslConnection(bool value) noexcept;
 
       // headers
-      void setHeader(const std::string & name, const std::string & value) noexcept;
+      void setHeader(const std::string & name,
+                     const std::string & value);
       void delHeader(const std::string & name) noexcept;
       void clearHeaders() noexcept;
   };
-
-  static Options defaultOptions;
 }
 
 #endif

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -93,7 +93,7 @@ namespace kuzzleio {
 
 
       Kuzzle(Protocol* protocol);
-      Kuzzle(Protocol* protocol, Options& options);
+      Kuzzle(Protocol* protocol, const Options& options);
       virtual ~Kuzzle();
 
       void connect();

--- a/include/websocket.hpp
+++ b/include/websocket.hpp
@@ -17,7 +17,7 @@ namespace kuzzleio {
     public:
     web_socket* _web_socket;
     WebSocket(const std::string& host);
-    WebSocket(const std::string& host, Options& options);
+    WebSocket(const std::string& host, const Options& options);
 
     std::list<EventListener*> getListeners(int) noexcept;
     std::list<EventListener*> getOnceListeners(int) noexcept;

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -130,9 +130,9 @@ namespace kuzzleio {
     return static_cast<Protocol*>(data)->getHost().c_str();
   }
 
-  Kuzzle::Kuzzle(Protocol* proto) : Kuzzle(proto, defaultOptions) {}
+  Kuzzle::Kuzzle(Protocol* proto) : Kuzzle(proto, Options()) {}
 
-  Kuzzle::Kuzzle(Protocol* proto, Options& options) {
+  Kuzzle::Kuzzle(Protocol* proto, const Options& options) {
     this->_kuzzle = new kuzzle();
 
     proto->_protocol = new protocol();

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -2,9 +2,9 @@
 
 namespace kuzzleio {
   WebSocket::WebSocket(const std::string& host)
-    : WebSocket(host, defaultOptions) {}
+    : WebSocket(host, Options()) {}
 
-  WebSocket::WebSocket(const std::string& host, Options& options) {
+  WebSocket::WebSocket(const std::string& host, const Options& options) {
     this->_web_socket = new web_socket();
 
     kuzzle_websocket_new_web_socket(


### PR DESCRIPTION
# Description

Using the C++ SDK in its current state results in programs hanging up while loading the SDK library.
The hangup is caused by the `defaultOptions` static, invoking the `Options` default constructor which, in turn, uses CGo.
Since that variable is static, it is initialized during the library load, before CGo has a chance to finish initializing its threads and mutexes. This results in a deadlock (see this related issue: https://github.com/golang/go/issues/26184 )

This PR fixes that issue by removing the need of a static "default options" variable. 
To do so, we need the Options `c_opts` method, which converts the C++ Options class into its equivalent `options` C struct, to be constant. This allows the use of delegating constructors without the need of a pre-allocated default Options instance.
