### PR TITLE
Bugfix: wrong iterator used

### DIFF
--- a/src/event_emitter.cpp
+++ b/src/event_emitter.cpp
@@ -74,7 +74,7 @@ namespace kuzzleio {
       const std::string& payload) noexcept {
     auto lset = this->onceListeners.find(e);
 
-    if (lset != this->listeners.end()) {
+    if (lset != this->onceListeners.end()) {
       for(auto l : lset->second) {
         (*l)(payload);
       }


### PR DESCRIPTION
# Description

Fix a crash caused by one-time event emitters, because an iterable was compared against the wrong map iterator. :sweat: 