### PR TITLE
CPP: Fix SearchResult getters

### DIFF
--- a/include/internal/search_result.hpp
+++ b/include/internal/search_result.hpp
@@ -24,23 +24,16 @@ namespace kuzzleio {
             search_result* _sr;
 
         public:
-            char const* aggregations() const;
-            char const* hits() const;
-            char const* scroll_id() const;
-            unsigned total() const;
-            unsigned fetched() const;
+            const std::string& aggregations() const;
+            const std::string& hits() const;
+            const std::string& scroll_id() const;
+            size_t total() const;
+            size_t fetched() const;
 
             SearchResult(search_result* sr);
             virtual ~SearchResult();
             virtual std::shared_ptr<SearchResult> next();
     };
-
-    class SpecificationSearchResult : public SearchResult {
-        public:
-            SpecificationSearchResult(const search_result* sr);
-            virtual ~SpecificationSearchResult();
-    };
-
 }
 
 #endif

--- a/src/search_result.cpp
+++ b/src/search_result.cpp
@@ -25,23 +25,23 @@ namespace kuzzleio {
     kuzzle_free_search_result(_sr);
   }
 
-  char const* SearchResult::aggregations() const {
+  const std::string& SearchResult::aggregations() const {
     return _sr->aggregations;
   }
 
-  char const* SearchResult::hits() const {
+  const std::string& SearchResult::hits() const {
     return _sr->hits;
   }
 
-  char const* SearchResult::scroll_id() const {
+  const std::string& SearchResult::scroll_id() const {
     return _sr->scroll_id;
   }
 
-  unsigned SearchResult::fetched() const {
+  size_t SearchResult::fetched() const {
     return _sr->fetched;
   }
 
-  unsigned SearchResult::total() const {
+  size_t SearchResult::total() const {
     return _sr->total;
   }
 


### PR DESCRIPTION
## What does this PR do ?

SearchResult getters now returns `const std::string&` and `size_t`.  

Useless SpecificationSearchResult class have been removed.

Context: https://github.com/kuzzleio/sdk-cpp/pull/56