### PR TITLE
Remove useless class SpecificationSearchResult

### DIFF
--- a/include/internal/search_result.hpp
+++ b/include/internal/search_result.hpp
@@ -34,13 +34,6 @@ namespace kuzzleio {
             virtual ~SearchResult();
             virtual std::shared_ptr<SearchResult> next();
     };
-
-    class SpecificationSearchResult : public SearchResult {
-        public:
-            SpecificationSearchResult(const search_result* sr);
-            virtual ~SpecificationSearchResult();
-    };
-
 }
 
 #endif


### PR DESCRIPTION
## What does this PR do ?

Remove useless class SpecificationSearchResult
