### PR TITLE
Fix erroneous pointer of function pointer

### DIFF
--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -12,7 +12,7 @@ namespace kuzzleio {
   class Protocol : public KuzzleEventEmitter {
     private:
       std::unordered_map<
-          kuzzle_event_listener*, SharedEventListener> bridgeListeners;
+          kuzzle_event_listener, SharedEventListener> bridgeListeners;
 
       std::unordered_map<
           std::string,
@@ -62,13 +62,13 @@ namespace kuzzleio {
 
       // internals -- used for bridging with golang
       using KuzzleEventEmitter::removeListener;
-      virtual void removeListener(int, kuzzle_event_listener*);
+      virtual void removeListener(int, kuzzle_event_listener);
 
       using KuzzleEventEmitter::addListener;
-      virtual void addListener(int, kuzzle_event_listener*);
+      virtual void addListener(int, kuzzle_event_listener);
 
       using KuzzleEventEmitter::once;
-      virtual void once(int, kuzzle_event_listener*);
+      virtual void once(int, kuzzle_event_listener);
 
       virtual void registerSub(
         const std::string& channel, const std::string& roomId,

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -19,7 +19,7 @@ namespace kuzzleio {
   // bridge functions
   static void bridge_cpp_remove_listener(
       int event,
-      kuzzle_event_listener* listener,
+      kuzzle_event_listener listener,
       void* _p) {
 
     static_cast<Protocol*>(_p)->removeListener(event, listener);
@@ -27,12 +27,12 @@ namespace kuzzleio {
 
   void bridge_cpp_add_listener(
       int event,
-      kuzzle_event_listener* listener,
+      kuzzle_event_listener listener,
       void* _p) {
     static_cast<Protocol*>(_p)->addListener(event, listener);
   }
 
-  void bridge_cpp_once(int event, kuzzle_event_listener* listener, void* _p) {
+  void bridge_cpp_once(int event, kuzzle_event_listener listener, void* _p) {
     static_cast<Protocol*>(_p)->addListener(event, listener);
   }
 
@@ -146,7 +146,7 @@ namespace kuzzleio {
   }
 
   // Protocol class implementation
-  void Protocol::addListener(int event, kuzzle_event_listener *listener) {
+  void Protocol::addListener(int event, kuzzle_event_listener listener) {
     auto bl = this->bridgeListeners.find(listener);
 
     if (bl == this->bridgeListeners.end()) {
@@ -164,7 +164,7 @@ namespace kuzzleio {
     }
   }
 
-  void Protocol::once(int event, kuzzle_event_listener *listener) {
+  void Protocol::once(int event, kuzzle_event_listener listener) {
     auto bl = bridgeListeners.find(listener);
 
     // do not add a "once" listener if a permanent one is already registered
@@ -185,7 +185,7 @@ namespace kuzzleio {
     }
   }
 
-  void Protocol::removeListener(int event, kuzzle_event_listener *listener) {
+  void Protocol::removeListener(int event, kuzzle_event_listener listener) {
     auto l = this->bridgeListeners.find(listener);
 
     if (l != this->bridgeListeners.end()) {
@@ -252,7 +252,7 @@ namespace kuzzleio {
       for (auto elistener : elisteners->second) {
         auto bridge = std::find_if(
             this->bridgeListeners.begin(), this->bridgeListeners.end(),
-            [=](std::pair<kuzzle_event_listener*, SharedEventListener> vt)
+            [=](std::pair<kuzzle_event_listener, SharedEventListener> vt)
             { return vt.second == elistener; });
 
         if (bridge != bridgeListeners.end()) {


### PR DESCRIPTION
:warning:  depends on https://github.com/kuzzleio/sdk-c/pull/55 :warning: 

# Description

The `kuzzle_event_listener` type is a typedef of a function pointer. Many bridges functions erroneously used the `kuzzle_event_listener*` type, meaning that they were taking a pointer over a variable storing a function pointer, meaning that dereferencing will not yield to a callable function (not mentioning the address becoming invalid as soon as the referenced variable becomes out of scope)