### PR TITLE
SWIG compatibility fixes

### DIFF
--- a/include/internal/event_emitter.hpp
+++ b/include/internal/event_emitter.hpp
@@ -17,8 +17,9 @@
 
 #include <functional>
 #include <memory>
-#include <unordered_map>
+#include <map>
 #include <set>
+#include <string>
 #include "internal/core.hpp"
 
 namespace kuzzleio {
@@ -33,8 +34,8 @@ namespace kuzzleio {
       virtual void emitEventOnce(Event, const std::string& payload) noexcept;
 
     protected:
-      std::unordered_map<Event, std::set<SharedEventListener>> listeners;
-      std::unordered_map<Event, std::set<SharedEventListener>> onceListeners;
+      std::map<Event, std::set<SharedEventListener>> listeners;
+      std::map<Event, std::set<SharedEventListener>> onceListeners;
 
     public:
       KuzzleEventEmitter() = default;

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -108,7 +108,6 @@ namespace kuzzleio {
       Kuzzle* flushQueue() noexcept;
       std::string getVolatile() noexcept;
       Kuzzle* setVolatile(const std::string& volatiles) noexcept;
-      std::map<int, EventListener*> getListeners() noexcept;
       Protocol* getProtocol() noexcept;
 
       // event emitter overrides

--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -2,7 +2,7 @@
 #define KUZZLE_PROTOCOL_HPP
 
 #include <string>
-#include <unordered_map>
+#include <map>
 #include <memory>
 #include "kuzzle.hpp"
 #include "internal/protocol.h"
@@ -11,19 +11,19 @@
 namespace kuzzleio {
   class Protocol : public KuzzleEventEmitter {
     private:
-      std::unordered_map<
+      std::map<
           kuzzle_event_listener, SharedEventListener> bridgeListeners;
 
-      std::unordered_map<
+      std::map<
           std::string,
-          std::unordered_map<
+          std::map<
             kuzzle_notification_listener,
             std::shared_ptr<NotificationListener>
           >
       > bridgeSubs;
 
     protected:
-      std::unordered_map<
+      std::map<
           std::string,
           std::set<std::shared_ptr<NotificationListener>>
       > notificationListeners;

--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -12,7 +12,7 @@ namespace kuzzleio {
   class Protocol : public KuzzleEventEmitter {
     private:
       std::unordered_map<
-          kuzzle_event_listener*, SharedEventListener> bridgeListeners;
+          kuzzle_event_listener, SharedEventListener> bridgeListeners;
 
       std::unordered_map<
           std::string,
@@ -62,13 +62,13 @@ namespace kuzzleio {
 
       // internals -- used for bridging with golang
       using KuzzleEventEmitter::removeListener;
-      virtual void removeListener(int, kuzzle_event_listener*);
+      virtual void removeListener(int, kuzzle_event_listener);
 
       using KuzzleEventEmitter::addListener;
-      virtual void addListener(int, kuzzle_event_listener*);
+      virtual void addListener(int, kuzzle_event_listener);
 
       using KuzzleEventEmitter::once;
-      virtual void once(int, kuzzle_event_listener*);
+      virtual void once(int, kuzzle_event_listener);
 
       virtual void registerSub(
         const std::string& channel, const std::string& roomId,

--- a/src/event_emitter.cpp
+++ b/src/event_emitter.cpp
@@ -2,9 +2,11 @@
 
 namespace kuzzleio {
   void _c_emit_event(int event, char* payload, void* ptr) {
+    std::string p = const_cast<const char*>(payload);
+
     static_cast<KuzzleEventEmitter*>(ptr)->emitEvent(
       static_cast<Event>(event),
-      payload);
+      p);
   }
 
   KuzzleEventEmitter* KuzzleEventEmitter::addListener(

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -19,7 +19,7 @@ namespace kuzzleio {
   // bridge functions
   static void bridge_cpp_remove_listener(
       int event,
-      kuzzle_event_listener* listener,
+      kuzzle_event_listener listener,
       void* _p) {
 
     static_cast<Protocol*>(_p)->removeListener(event, listener);
@@ -27,12 +27,12 @@ namespace kuzzleio {
 
   void bridge_cpp_add_listener(
       int event,
-      kuzzle_event_listener* listener,
+      kuzzle_event_listener listener,
       void* _p) {
     static_cast<Protocol*>(_p)->addListener(event, listener);
   }
 
-  void bridge_cpp_once(int event, kuzzle_event_listener* listener, void* _p) {
+  void bridge_cpp_once(int event, kuzzle_event_listener listener, void* _p) {
     static_cast<Protocol*>(_p)->addListener(event, listener);
   }
 
@@ -146,7 +146,7 @@ namespace kuzzleio {
   }
 
   // Protocol class implementation
-  void Protocol::addListener(int event, kuzzle_event_listener *listener) {
+  void Protocol::addListener(int event, kuzzle_event_listener listener) {
     auto bl = this->bridgeListeners.find(listener);
 
     if (bl == this->bridgeListeners.end()) {
@@ -164,7 +164,7 @@ namespace kuzzleio {
     }
   }
 
-  void Protocol::once(int event, kuzzle_event_listener *listener) {
+  void Protocol::once(int event, kuzzle_event_listener listener) {
     auto bl = bridgeListeners.find(listener);
 
     // do not add a "once" listener if a permanent one is already registered
@@ -185,7 +185,7 @@ namespace kuzzleio {
     }
   }
 
-  void Protocol::removeListener(int event, kuzzle_event_listener *listener) {
+  void Protocol::removeListener(int event, kuzzle_event_listener listener) {
     auto l = this->bridgeListeners.find(listener);
 
     if (l != this->bridgeListeners.end()) {
@@ -252,7 +252,7 @@ namespace kuzzleio {
       for (auto elistener : elisteners->second) {
         auto bridge = std::find_if(
             this->bridgeListeners.begin(), this->bridgeListeners.end(),
-            [=](std::pair<kuzzle_event_listener*, SharedEventListener> vt)
+            [=](std::pair<kuzzle_event_listener, SharedEventListener> vt)
             { return vt.second == elistener; });
 
         if (bridge != bridgeListeners.end()) {


### PR DESCRIPTION
# Description

Fix a various incompatibilities/errors when using this SDK with SWIG:
* `std::unordered_map` is unsupported by old Android SDKs: using this class with Android APIs 19&21 leads to obscure errors about a Hash class being undeclared
* `kuzzle.hpp` still showed a `getListeners` method but, as it was obsolete, its implementation was removed a few commits ago. Having it still there forces SWIG to generate a wrapper referencing an unknown method in the C++ library