### PR TITLE
Properly isolate SDK objects in the kuzzleio namespace

### DIFF
--- a/include/internal/core.hpp
+++ b/include/internal/core.hpp
@@ -16,10 +16,13 @@
 #define _CORE_HPP_
 #define _Bool bool
 #include <cstdio>
+#include <ctime>
 
-extern "C" {
+#include "internal/kuzzle_structs.h"
+#include "internal/protocol.h"
+
+namespace kuzzleio {
   #include "internal/kuzzle.h"
-  #include "internal/kuzzle_structs.h"
 }
 
 #endif

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -38,6 +38,7 @@
 #include "internal/user_right.hpp"
 #include "internal/user.hpp"
 
+namespace kuzzleio {
 /*
  * Macro used by controller actions.
  * This standardizes and DRYifies the following process, making sure
@@ -67,7 +68,6 @@
     throwKuzzleException(status, err); \
   }
 
-namespace kuzzleio {
   class Collection;
   class Document;
   class Auth;

--- a/test/features/step_definitions/auth-steps.cpp
+++ b/test/features/step_definitions/auth-steps.cpp
@@ -38,14 +38,14 @@ namespace {
   THEN("^the JWT is valid$")
   {
     ScenarioScope<KuzzleCtx> ctx;
-    token_validity* v = ctx->kuzzle->auth->checkToken(ctx->jwt);
+    kuzzleio::token_validity* v = ctx->kuzzle->auth->checkToken(ctx->jwt);
     BOOST_CHECK(v->valid);
   }
 
   THEN("^the JWT is invalid$")
   {
     ScenarioScope<KuzzleCtx> ctx;
-    token_validity*          v = ctx->kuzzle->auth->checkToken(ctx->jwt);
+    kuzzleio::token_validity* v = ctx->kuzzle->auth->checkToken(ctx->jwt);
     BOOST_CHECK(!v->valid);
   }
   WHEN("^I logout$") {
@@ -59,7 +59,7 @@ namespace {
 
     try {
       ctx->currentUser = ctx->kuzzle->auth->getCurrentUser();
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
 
@@ -73,7 +73,7 @@ namespace {
     try {
       ctx->user_rights = ctx->kuzzle->auth->getMyRights();
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       ctx->success = 0;
       K_LOG_E(e.what());
     }

--- a/test/features/step_definitions/collection-steps.cpp
+++ b/test/features/step_definitions/collection-steps.cpp
@@ -5,33 +5,35 @@
 namespace {
   WHEN("^I create a collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id);
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
 
   THEN("^the collection \'([^\"]*)\' should exist$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    BOOST_CHECK(ctx->kuzzle->collection->exists(ctx->index, collection_id) == true);
+    BOOST_CHECK(
+        ctx->kuzzle->collection->exists(ctx->index, collection_id) == true);
   }
 
   WHEN("^I check if the collection \'([^\"]*)\' exists$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    ctx->success = ctx->kuzzle->collection->exists(ctx->index, collection_id) ? 1 : 0;
+    ctx->success =
+        ctx->kuzzle->collection->exists(ctx->index, collection_id) ? 1 : 0;
   }
 
   THEN("^the collection should exist$")
@@ -43,7 +45,7 @@ namespace {
 
   GIVEN("^it has a collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, collection_name);
+    REGEX_PARAM(std::string, collection_name);
 
     ScenarioScope<KuzzleCtx> ctx;
     ctx->collection = collection_name;
@@ -51,7 +53,7 @@ namespace {
     K_LOG_D("Creating collection: %s", collection_name.c_str());
     try {
       ctx->kuzzle->collection->create(ctx->index, ctx->collection);
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       K_LOG_E(e.what());
       BOOST_FAIL(e.what());
     }
@@ -59,7 +61,7 @@ namespace {
 
   WHEN("^I list the collections of \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, index_name);
+    REGEX_PARAM(std::string, index_name);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -74,23 +76,25 @@ namespace {
 
   GIVEN("^the collection has a document with id \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, document_id);
+    REGEX_PARAM(std::string, document_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    query_options options;
+    kuzzleio::query_options options;
     options.refresh = const_cast<char*>("wait_for");
 
-    ctx->kuzzle->document->create(ctx->index, ctx->collection, document_id, "{\"a\":\"document\"}", options);
+    ctx->kuzzle->document->create(
+        ctx->index, ctx->collection, document_id, "{\"a\":\"document\"}",
+        options);
   }
 
   WHEN("^I truncate the collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    query_options options;
+    kuzzleio::query_options options;
     options.refresh = const_cast<char*>("wait_for");
 
     ctx->kuzzle->collection->truncate(ctx->index, collection_id, options);
@@ -98,75 +102,83 @@ namespace {
 
   THEN("^the collection \'([^\"]*)\' should be empty$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    std::shared_ptr<SearchResult> result = ctx->kuzzle->document->search(
-        ctx->index,
-        collection_id,
-        "{}");
+    std::shared_ptr<kuzzleio::SearchResult> result =
+        ctx->kuzzle->document->search(ctx->index, collection_id, "{}");
 
     BOOST_CHECK(result->total() == 0);
   }
 
   WHEN("^I update the mapping of collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string mapping = "{\"properties\": {\"gordon\": {\"type\": \"keyword\"}}}";
+    std::string mapping = R"({"properties": {"gordon": {"type": "keyword"}}})";
 
     ctx->kuzzle->collection->updateMapping(ctx->index, collection_id, mapping);
   }
 
   THEN("^the mapping of \'([^\"]*)\' should be updated$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string mapping = ctx->kuzzle->collection->getMapping(ctx->index, collection_id);
+    std::string mapping = ctx->kuzzle->collection->getMapping(
+        ctx->index, collection_id);
 
-    BOOST_CHECK(mapping.find("\"gordon\":{\"type\":\"keyword\"}") != string::npos);
+    BOOST_CHECK(
+        mapping.find(R"%("gordon":{"type":"keyword"})%") != std::string::npos);
   }
 
   WHEN("^I update the specifications of the collection \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string specifications = "{\"strict\":false}";
+    std::string specifications = R"%({"strict":false})%";
 
-    ctx->kuzzle->collection->updateSpecifications(ctx->index, collection_id, specifications);
+    ctx->kuzzle->collection->updateSpecifications(
+        ctx->index, collection_id, specifications);
   }
 
   THEN("^the specifications of \'([^\"]*)\' should be updated$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string specifications = ctx->kuzzle->collection->getSpecifications(ctx->index, collection_id);
-    string expected_specifications = "{\"validation\":{\"strict\":false},\"index\":\"" + ctx->index + "\",\"collection\":\"" + collection_id + "\"}";
+    std::string specifications = ctx->kuzzle->collection->getSpecifications(
+        ctx->index, collection_id);
+    std::string expected_specifications =
+        R"%({"validation":{"strict":false},"index":")%" + ctx->index +
+        R"%(","collection":")%" + collection_id + R"%("})%";
 
     BOOST_CHECK(specifications == expected_specifications);
 
-    specifications = "{\"strict\":true}";
-    ctx->kuzzle->collection->updateSpecifications(ctx->index, collection_id, specifications);
+    specifications = R"%({"strict":true})%";
+    ctx->kuzzle->collection->updateSpecifications(
+        ctx->index, collection_id, specifications);
   }
 
   WHEN("^I validate the specifications of \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string specifications = "{\"strict\":true}";
+    std::string specifications = R"%({"strict":true})%";
 
-    kuzzleio::validation_response *validationResponse = ctx->kuzzle->collection->validateSpecifications(ctx->index, ctx->collection, specifications);
+    kuzzleio::validation_response *validationResponse =
+        ctx->kuzzle->collection->validateSpecifications(
+            ctx->index, ctx->collection, specifications);
+
     ctx->success = validationResponse->valid;
   }
 
@@ -181,14 +193,15 @@ namespace {
   {
     ScenarioScope<KuzzleCtx> ctx;
 
-    string specifications = "{\"strict\":true}";
+    std::string specifications = R"%({"strict":true})%";
 
-    ctx->kuzzle->collection->updateSpecifications(ctx->index, ctx->collection, specifications);
+    ctx->kuzzle->collection->updateSpecifications(
+        ctx->index, ctx->collection, specifications);
   }
 
   WHEN("^I delete the specifications of \'([^\"]*)\'$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
@@ -197,23 +210,26 @@ namespace {
 
   THEN("^the specifications of \'([^\"]*)\' must not exist$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    BOOST_CHECK(ctx->kuzzle->collection->getSpecifications(ctx->index, collection_id) == "");
+    std::string res = ctx->kuzzle->collection->getSpecifications(
+        ctx->index, collection_id);
+
+    BOOST_CHECK(res == "");
   }
 
   WHEN("^I create a collection \'([^\"]*)\' with a mapping$")
   {
-    REGEX_PARAM(string, collection_id);
+    REGEX_PARAM(std::string, collection_id);
 
     ScenarioScope<KuzzleCtx> ctx;
-    string mapping = "{\"properties\": {\"gordon\": {\"type\": \"keyword\"}}}";
+    std::string mapping = R"%({"properties":{"gordon":{"type":"keyword"}}})%";
 
     try {
       ctx->kuzzle->collection->create(ctx->index, collection_id, mapping);
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }

--- a/test/features/step_definitions/document-steps.cpp
+++ b/test/features/step_definitions/document-steps.cpp
@@ -9,12 +9,14 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->create(ctx->index, ctx->collection, document_id, "{\"a\":\"document\"}", options);
+      ctx->kuzzle->document->create(
+          ctx->index, ctx->collection, document_id, R"%({"a":"document"})%",
+          options);
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       ctx->success = 0;
       ctx->error_message = e.what();
     }
@@ -43,11 +45,12 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id, options);
-    } catch (KuzzleException e) {
+      ctx->kuzzle->document->delete_(
+          ctx->index, ctx->collection, document_id, options);
+    } catch (kuzzleio::KuzzleException e) {
       ctx->error_message = e.what();
       ctx->success = 0;
     }
@@ -59,13 +62,15 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->createOrReplace(ctx->index, ctx->collection, document_id, "{\"a\":\"replaced document\"}", options);
+      ctx->kuzzle->document->createOrReplace(
+          ctx->index, ctx->collection, document_id,
+          R"%({"a":"replaced document"})%", options);
       ctx->document_id = document_id;
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -74,7 +79,8 @@ namespace {
   {
     ScenarioScope<KuzzleCtx> ctx;
 
-    string document = ctx->kuzzle->document->get(ctx->index, ctx->collection, ctx->document_id);
+    std::string document = ctx->kuzzle->document->get(
+        ctx->index, ctx->collection, ctx->document_id);
 
     BOOST_CHECK(ctx->success == 1);
     BOOST_CHECK(document.find("replaced document") != std::string::npos);
@@ -87,13 +93,15 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->replace(ctx->index, ctx->collection, document_id, "{\"a\":\"replaced document\"}", options);
+      ctx->kuzzle->document->replace(
+          ctx->index, ctx->collection, document_id,
+          R"%({"a":"replaced document"})%", options);
       ctx->document_id = document_id;
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -112,13 +120,15 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\"a\":\"updated document\"}", options);
+      ctx->kuzzle->document->update(
+          ctx->index, ctx->collection, document_id,
+          R"%({"a":"updated document"})%", options);
       ctx->document_id = document_id;
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -127,7 +137,8 @@ namespace {
   {
     ScenarioScope<KuzzleCtx> ctx;
 
-    string document = ctx->kuzzle->document->get(ctx->index, ctx->collection, ctx->document_id);
+    std::string document = ctx->kuzzle->document->get(
+        ctx->index, ctx->collection, ctx->document_id);
 
     BOOST_CHECK(ctx->success == 1);
     BOOST_CHECK(document.find("updated document") != std::string::npos);
@@ -138,11 +149,14 @@ namespace {
     REGEX_PARAM(std::string, document_id);
 
     ScenarioScope<KuzzleCtx> ctx;
+    std::string squery = R"%({"query":{"bool":{"should":[{"match":{"_id": ")%"
+        + document_id + R"%("}}]}}})%";
 
     try {
-      ctx->search_result = ctx->kuzzle->document->search(ctx->index, ctx->collection, "{\"query\": {\"bool\": {\"should\":[{\"match\":{\"_id\": \"" + document_id + "\"}}]}}}");
+      ctx->search_result = ctx->kuzzle->document->search(
+          ctx->index, ctx->collection, squery);
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -160,8 +174,9 @@ namespace {
       options.from = from;
       options.size = size;
 
-      ctx->search_result = ctx->kuzzle->document->search(ctx->index, ctx->collection, query, options);
-    } catch (KuzzleException e) {
+      ctx->search_result = ctx->kuzzle->document->search(
+          ctx->index, ctx->collection, query, options);
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -172,7 +187,7 @@ namespace {
 
     try {
       ctx->search_result = ctx->search_result->next();
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -196,8 +211,9 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      ctx->hits = ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}");
-    } catch (KuzzleException e) {
+      ctx->hits = ctx->kuzzle->document->count(
+          ctx->index, ctx->collection, "{}");
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -210,20 +226,21 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      std::vector<string> document_ids;
+      std::vector<std::string> document_ids;
       document_ids.push_back(document1_id);
       document_ids.push_back(document2_id);
 
-      ctx->kuzzle->document->mDelete(ctx->index, ctx->collection, document_ids, options);
+      ctx->kuzzle->document->mDelete(
+          ctx->index, ctx->collection, document_ids, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
-    } catch (PartialException e) {
+    } catch (kuzzleio::PartialException e) {
       ctx->partial_exception = 1;
       ctx->success = 0;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -235,8 +252,10 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      BOOST_CHECK(ctx->kuzzle->document->count(ctx->index, ctx->collection, "{}") == documents_count);
-    } catch (KuzzleException e) {
+      unsigned int res = ctx->kuzzle->document->count(
+          ctx->index, ctx->collection, "{}");
+      BOOST_CHECK(res == documents_count);
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -249,17 +268,19 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{}}, {\"_id\":\"" + document2_id + "\", \"body\":{}}]";
-      ctx->kuzzle->document->mCreate(ctx->index, ctx->collection, documents, options);
+      std::string documents = R"([{"_id":")" + document1_id
+          + R"(", "body":{}}, {"_id":")" + document2_id + R"(", "body":{}}])";
+      ctx->kuzzle->document->mCreate(
+          ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
-    } catch (PartialException e) {
+    } catch (kuzzleio::PartialException e) {
       ctx->partial_exception = 1;
       ctx->success = 0;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -272,17 +293,20 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{\"a\":\"replaced document\"}}, {\"_id\":\"" + document2_id + "\", \"body\":{\"a\":\"replaced document\"}}]";
-      ctx->kuzzle->document->mReplace(ctx->index, ctx->collection, documents, options);
+      std::string documents = R"([{"_id":")" + document1_id
+          + R"(", "body":{"a":"replaced document"}}, {"_id":")" + document2_id
+          + R"(", "body":{"a":"replaced document"}}])";
+      ctx->kuzzle->document->mReplace(
+          ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
-    } catch (PartialException e) {
+    } catch (kuzzleio::PartialException e) {
       ctx->partial_exception = 1;
       ctx->success = 0;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -293,7 +317,8 @@ namespace {
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string document = ctx->kuzzle->document->get(ctx->index, ctx->collection, document_id);
+    std::string document = ctx->kuzzle->document->get(
+        ctx->index, ctx->collection, document_id);
 
     BOOST_CHECK(document.find("replaced document") != std::string::npos);
   }
@@ -306,17 +331,20 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{\"a\":\"replaced document\"}}, {\"_id\":\"" + document2_id + "\", \"body\":{\"a\":\"replaced document\"}}]";
-      ctx->kuzzle->document->mUpdate(ctx->index, ctx->collection, documents, options);
+      std::string documents = R"([{"_id":")" + document1_id
+          + R"(", "body":{"a":"replaced document"}}, {"_id":")" + document2_id
+          + R"(", "body":{"a":"replaced document"}}])";
+      ctx->kuzzle->document->mUpdate(
+          ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
-    } catch (PartialException e) {
+    } catch (kuzzleio::PartialException e) {
       ctx->partial_exception = 1;
       ctx->success = 0;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -327,7 +355,8 @@ namespace {
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string document = ctx->kuzzle->document->get(ctx->index, ctx->collection, document_id);
+    std::string document = ctx->kuzzle->document->get(
+        ctx->index, ctx->collection, document_id);
 
     BOOST_CHECK(document.find("replaced document") != std::string::npos);
   }
@@ -340,17 +369,20 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      query_options options;
+      kuzzleio::query_options options;
       options.refresh = const_cast<char*>("wait_for");
 
-      string documents = "[{\"_id\":\"" + document1_id + "\", \"body\":{\"a\":\"replaced document\"}}, {\"_id\":\"" + document2_id + "\", \"body\":{\"a\":\"replaced document\"}}]";
-      ctx->kuzzle->document->mCreateOrReplace(ctx->index, ctx->collection, documents, options);
+      std::string documents = R"([{"_id":")" + document1_id
+          + R"(", "body":{"a":"replaced document"}}, {"_id":")" + document2_id
+          + R"(", "body":{"a":"replaced document"}}])";
+      ctx->kuzzle->document->mCreateOrReplace(
+          ctx->index, ctx->collection, documents, options);
       ctx->success = 1;
       ctx->partial_exception = 0;
-    } catch (PartialException e) {
+    } catch (kuzzleio::PartialException e) {
       ctx->partial_exception = 1;
       ctx->success = 0;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -361,7 +393,8 @@ namespace {
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    string document = ctx->kuzzle->document->get(ctx->index, ctx->collection, document_id);
+    std::string document = ctx->kuzzle->document->get(
+        ctx->index, ctx->collection, document_id);
 
     BOOST_CHECK(document.find("replaced document") != std::string::npos);
   }
@@ -372,7 +405,8 @@ namespace {
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    ctx->success = ctx->kuzzle->document->exists(ctx->index, ctx->collection, document_id) ? 1 : 0;
+    ctx->success = ctx->kuzzle->document->exists(
+        ctx->index, ctx->collection, document_id) ? 1 : 0;
   }
 
   THEN("^the document should (not )?exist(s)?$")
@@ -395,13 +429,14 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      std::vector<string> document_ids;
+      std::vector<std::string> document_ids;
       document_ids.push_back(document1_id);
       document_ids.push_back(document2_id);
 
-      ctx->content = ctx->kuzzle->document->mGet(ctx->index, ctx->collection, document_ids);
+      ctx->content = ctx->kuzzle->document->mGet(
+          ctx->index, ctx->collection, document_ids);
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       ctx->success = 0;
     }
   }

--- a/test/features/step_definitions/index-steps.cpp
+++ b/test/features/step_definitions/index-steps.cpp
@@ -11,7 +11,7 @@ namespace {
 
     try {
       ctx->kuzzle->index->delete_(index_name);
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       K_LOG_E(e.what());
       BOOST_FAIL(e.what());
     }
@@ -27,7 +27,7 @@ namespace {
       K_LOG_D("Creating index: %s", index_name.c_str());
       try {
         ctx->kuzzle->index->create(index_name);
-      } catch (KuzzleException e) {
+      } catch (kuzzleio::KuzzleException e) {
         K_LOG_E(e.what());
         BOOST_FAIL(e.what());
       }
@@ -45,7 +45,7 @@ namespace {
     if (! ctx->kuzzle->index->exists(index_name1)) {
       try {
         ctx->kuzzle->index->create(index_name1);
-      } catch(KuzzleException e) {
+      } catch(kuzzleio::KuzzleException e) {
         K_LOG_E(e.what());
         BOOST_FAIL(e.what());
       }
@@ -56,7 +56,7 @@ namespace {
     if (! ctx->kuzzle->index->exists(index_name2)) {
       try {
         ctx->kuzzle->index->create(index_name2);
-      } catch(KuzzleException e) {
+      } catch(kuzzleio::KuzzleException e) {
         K_LOG_E(e.what());
         BOOST_FAIL(e.what());
       }
@@ -78,7 +78,7 @@ namespace {
 
     try {
       ctx->kuzzle->index->mDelete(v);
-    } catch(KuzzleException e) {
+    } catch(kuzzleio::KuzzleException e) {
       K_LOG_E(e.what());
       BOOST_FAIL(e.what());
     }
@@ -94,7 +94,7 @@ namespace {
     try {
       ctx->kuzzle->index->create(index_name);
       ctx->index = index_name;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       ctx->success = false;
       K_LOG_E(e.what());
     }

--- a/test/features/step_definitions/kuzzle_utils.cpp
+++ b/test/features/step_definitions/kuzzle_utils.cpp
@@ -63,7 +63,6 @@ bool kuzzle_user_exists(kuzzleio::Kuzzle *kuzzle, const std::string &user_id) {
   }
   catch (kuzzleio::KuzzleException e) {
     K_LOG_W(e.what());
-    throw e;
   }
   return user_exists;
 }
@@ -87,7 +86,6 @@ void kuzzle_user_delete(kuzzleio::Kuzzle *kuzzle, const std::string &user_id)
   }
   catch (kuzzleio::KuzzleException e) {
     K_LOG_E("Failed to delete user \"%s\"", user_id.c_str());
-    throw e;
   }
 }
 
@@ -111,7 +109,6 @@ void kuzzle_credentials_delete(
     K_LOG_E("Failed to delete '%s' credentials for userId '%s'",
             strategy.c_str(), user_id.c_str());
     K_LOG_E(e.what());
-    throw e;
   }
 }
 

--- a/test/features/step_definitions/kuzzle_utils.cpp
+++ b/test/features/step_definitions/kuzzle_utils.cpp
@@ -5,56 +5,39 @@
 #include <map>
 #include <sstream>
 
-#include <kuzzle.hpp>
+#include "kuzzle.hpp"
 #include "kuzzle_utils.h"
-
-using boost::property_tree::ptree;
-using boost::property_tree::read_json;
-using boost::property_tree::write_json;
-
-using kuzzleio::Kuzzle;
-using kuzzleio::KuzzleException;
-using std::cout;
-using std::endl;
-using std::string;
-
-using json_spirit::Array;
-using json_spirit::Object;
-using json_spirit::Pair;
-using json_spirit::Value;
 
 std::string get_login_creds(const std::string &username,
                             const std::string &password)
 {
   // Write json.
-  ptree pt;
+  boost::property_tree::ptree pt;
   pt.put("username", username);
   pt.put("password", password);
   std::ostringstream buf;
-  write_json(buf, pt, false);
+  boost::property_tree::write_json(buf, pt, false);
   return buf.str();
 }
 
-string get_createUser_body(const std::string &username,
-                           const std::string &password)
-{
-  // Write json.
+std::string get_createUser_body(const std::string &username,
+                                const std::string &password) {
+  using json_spirit::Object;
+  using json_spirit::Pair;
+  using json_spirit::Value;
 
-  Object body;
-  Object content;
-  Object creds;
-  Object local;
+  Object body, content, creds, local;
 
   local.push_back(Pair("username", Value(username)));
   local.push_back(Pair("password", Value(password)));
 
   creds.push_back(Pair("local", Value(local)));
 
-  Array profileIds;
+  json_spirit::Array profileIds;
   profileIds.push_back("default");
 
-  content.push_back(json_spirit::Pair("profileIds", Value(profileIds)));
-  content.push_back(json_spirit::Pair("name", Value(username)));
+  content.push_back(Pair("profileIds", Value(profileIds)));
+  content.push_back(Pair("name", Value(username)));
 
   body.push_back(Pair("content", Value(content)));
   body.push_back(Pair("credentials", Value(creds)));
@@ -65,58 +48,55 @@ string get_createUser_body(const std::string &username,
   return buf.str();
 }
 
-bool kuzzle_user_exists(Kuzzle *kuzzle, const string &user_id)
-{
+bool kuzzle_user_exists(kuzzleio::Kuzzle *kuzzle, const std::string &user_id) {
   bool user_exists = false;
-  try
-  {
-    kuzzle_request req = {0};
+  try {
+    kuzzleio::kuzzle_request req = {0};
     req.controller = "security";
     req.action = "getUser";
     req.id = user_id.c_str();
     kuzzle->query(req);
     user_exists = true;
   }
-  catch (kuzzleio::NotFoundException e)
-  {
+  catch (kuzzleio::NotFoundException e) {
     user_exists = false;
   }
-  catch (KuzzleException e)
-  {
+  catch (kuzzleio::KuzzleException e) {
     K_LOG_W(e.what());
+    throw e;
   }
   return user_exists;
 }
 
-void kuzzle_user_delete(Kuzzle *kuzzle, const string &user_id)
+void kuzzle_user_delete(kuzzleio::Kuzzle *kuzzle, const std::string &user_id)
 {
   K_LOG_D("Deleting user with ID: '%s'", user_id.c_str());
   try
   {
-    kuzzle_request req = {0};
+    kuzzleio::kuzzle_request req = {0};
     req.controller = "security";
     req.action = "deleteUser";
     req.id = user_id.c_str();
 
-    query_options options;
+    kuzzleio::query_options options;
     options.refresh = const_cast<char*>("wait_for");
     options.volatiles = const_cast<char*>("{}");
     kuzzle->query(req, options); // TODO: test if we can delete with options
 
     K_LOG_D("Deleted user \"%s\"", user_id.c_str());
   }
-  catch (KuzzleException e)
-  {
+  catch (kuzzleio::KuzzleException e) {
     K_LOG_E("Failed to delete user \"%s\"", user_id.c_str());
+    throw e;
   }
 }
 
-void kuzzle_credentials_delete(Kuzzle *kuzzle, const string &strategy,
-                               const string &user_id)
-{
-  try
-  {
-    kuzzle_request req = {0};
+void kuzzle_credentials_delete(
+    kuzzleio::Kuzzle *kuzzle,
+    const std::string &strategy,
+    const std::string &user_id) {
+  try {
+    kuzzleio::kuzzle_request req = {0};
     req.controller = "security";
     req.action = "deleteCredentials";
     req.strategy = "local";
@@ -127,24 +107,23 @@ void kuzzle_credentials_delete(Kuzzle *kuzzle, const string &strategy,
     K_LOG_D("Deleted '%s' credentials for userId '%s'", strategy.c_str(),
             user_id.c_str());
   }
-  catch (KuzzleException e)
-  {
+  catch (kuzzleio::KuzzleException e) {
     K_LOG_E("Failed to delete '%s' credentials for userId '%s'",
             strategy.c_str(), user_id.c_str());
     K_LOG_E(e.what());
+    throw e;
   }
 }
 
-void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
-                        const string &username, const string &password)
-{
-
-  kuzzle_request req = {0};
+void kuzzle_user_create(kuzzleio::Kuzzle *kuzzle, const std::string &user_id,
+                        const std::string &username,
+                        const std::string &password) {
+  kuzzleio::kuzzle_request req = {0};
   req.controller = "security";
   req.action = "createUser";
   req.strategy = "local";
   req.id = user_id.c_str();
-  string body = get_createUser_body(username, password);
+  std::string body = get_createUser_body(username, password);
   req.body = body.c_str();
 
  // if (kuzzle_user_exists(kuzzle, user_id.c_str()))
@@ -162,10 +141,10 @@ void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
   K_LOG_D("Req body: %s", req.body);
   try
   {
-    kuzzle_response *resp = kuzzle->query(req);
+    kuzzleio::kuzzle_response *resp = kuzzle->query(req);
     K_LOG_D("createUser ended with status: %d", resp->status);
   }
-  catch (KuzzleException e)
+  catch (kuzzleio::KuzzleException e)
   {
     K_LOG_E("Status (%d): %s", e.status(), e.what());
     if (kuzzle_user_exists(kuzzle, user_id.c_str())) {
@@ -176,12 +155,12 @@ void kuzzle_user_create(Kuzzle *kuzzle, const string &user_id,
 
 void kuz_log_sep()
 {
-  cout << "\x1b(0\x6c\x1b(B";
+  std::cout << "\x1b(0\x6c\x1b(B";
   for (int i = 0; i < 79; i++)
   {
-    cout << "\x1b(0\x71\x1b(B";
+    std::cout << "\x1b(0\x71\x1b(B";
   }
-  cout << endl;
+  std::cout << std::endl;
 }
 
 void kuz_log_e(const char *filename, int linenumber, const char *fmt...)
@@ -189,10 +168,10 @@ void kuz_log_e(const char *filename, int linenumber, const char *fmt...)
   va_list args;
   va_start(args, fmt);
 
-  cout << "\x1b(0\x78\x1b(B" << TXT_COLOR_RED << "E:";
-  cout << basename(filename) << ":" << linenumber << ":";
+  std::cerr << "\x1b(0\x78\x1b(B" << TXT_COLOR_RED << "E:";
+  std::cerr << basename(filename) << ":" << linenumber << ":";
   vprintf(fmt, args);
-  std::cout << TXT_COLOR_RESET << std::endl;
+  std::cerr << TXT_COLOR_RESET << std::endl;
 
   va_end(args);
 }
@@ -201,10 +180,10 @@ void kuz_log_w(const char *filename, int linenumber, const char *fmt...)
 {
   va_list args;
   va_start(args, fmt);
-  cout << "\x1b(0\x78\x1b(B" << TXT_COLOR_YELLOW << "W:";
-  cout << basename(filename) << ":" << linenumber << ":";
+  std::cout << "\x1b(0\x78\x1b(B" << TXT_COLOR_YELLOW << "W:";
+  std::cout << basename(filename) << ":" << linenumber << ":";
   vprintf(fmt, args);
-  cout << TXT_COLOR_RESET << endl;
+  std::cout << TXT_COLOR_RESET << std::endl;
 
   va_end(args);
 }
@@ -214,10 +193,10 @@ void kuz_log_d(const char *filename, int linenumber, const char *fmt...)
   va_list args;
   va_start(args, fmt);
 
-  cout << "\x1b(0\x78\x1b(B" << TXT_COLOR_DEFAULT << "D:";
-  cout << basename(filename) << ":" << linenumber << ":";
+  std::cout << "\x1b(0\x78\x1b(B" << TXT_COLOR_DEFAULT << "D:";
+  std::cout << basename(filename) << ":" << linenumber << ":";
   vprintf(fmt, args);
-  cout << TXT_COLOR_RESET << endl;
+  std::cout << TXT_COLOR_RESET << std::endl;
 
   va_end(args);
 }
@@ -227,10 +206,10 @@ void kuz_log_i(const char *filename, int linenumber, const char *fmt...)
   va_list args;
   va_start(args, fmt);
 
-  cout << "\x1b(0\x78\x1b(B" << TXT_COLOR_BLUE << "I:";
-  cout << basename(filename) << ":" << linenumber << ":";
+  std::cout << "\x1b(0\x78\x1b(B" << TXT_COLOR_BLUE << "I:";
+  std::cout << basename(filename) << ":" << linenumber << ":";
   vprintf(fmt, args);
-  cout << TXT_COLOR_RESET << endl;
+  std::cout << TXT_COLOR_RESET << std::endl;
 
   va_end(args);
 }

--- a/test/features/step_definitions/kuzzle_utils.h
+++ b/test/features/step_definitions/kuzzle_utils.h
@@ -1,8 +1,8 @@
 #ifndef _KUZZLE_UTIL_HPP_
 #define _KUZZLE_UTIL_HPP_
 
-#include <stdarg.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
 #define TXT_COLOR_RESET "\e[0m"
 
 #define TXT_COLOR_DEFAULT "\e[39m"

--- a/test/features/step_definitions/realtime-steps.cpp
+++ b/test/features/step_definitions/realtime-steps.cpp
@@ -15,8 +15,9 @@ namespace {
       CustomNotificationListener *l =
           CustomNotificationListener::getSingleton();
       ctx->notif_result = nullptr;
-      ctx->room_id = ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, "{}", &l->listener);
-    } catch (KuzzleException e) {
+      ctx->room_id = ctx->kuzzle->realtime->subscribe(
+          ctx->index, collection_id, "{}", &l->listener);
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -26,12 +27,13 @@ namespace {
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    query_options options;
+    kuzzleio::query_options options;
     options.refresh = const_cast<char*>("wait_for");
 
     try {
-      ctx->kuzzle->document->create(ctx->index, ctx->collection, "", R"({"foo":"bar"})", options);
-    } catch (KuzzleException e) {
+      ctx->kuzzle->document->create(
+          ctx->index, ctx->collection, "", R"({"foo":"bar"})", options);
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -53,10 +55,11 @@ namespace {
     ScenarioScope<KuzzleCtx> ctx;
 
     try {
-      CustomNotificationListener *l = CustomNotificationListener::getSingleton();
-      ctx->kuzzle->realtime->subscribe(ctx->index, collection_id, filter,
-                                       &l->listener);
-    } catch (KuzzleException e) {
+      CustomNotificationListener *l =
+          CustomNotificationListener::getSingleton();
+      ctx->kuzzle->realtime->subscribe(
+          ctx->index, collection_id, filter, &l->listener);
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -68,12 +71,14 @@ namespace {
 
     ScenarioScope<KuzzleCtx> ctx;
 
-    query_options options;
+    kuzzleio::query_options options;
     options.refresh = const_cast<char*>("wait_for");
 
     try {
-      ctx->kuzzle->document->update(ctx->index, ctx->collection, document_id, "{\""+key+"\":\""+value+"\"}", options);
-    } catch (KuzzleException e) {
+      ctx->kuzzle->document->update(
+          ctx->index, ctx->collection, document_id,
+          "{\"" + key + "\":\"" + value + "\"}", options);
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -86,7 +91,7 @@ namespace {
     try {
       ctx->kuzzle->document->delete_(ctx->index, ctx->collection, document_id);
       ctx->success = 1;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -96,7 +101,7 @@ namespace {
 
     try {
       ctx->kuzzle->realtime->publish(ctx->index, ctx->collection, "{}");
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }
@@ -107,7 +112,7 @@ namespace {
     try {
       ctx->kuzzle->realtime->unsubscribe(ctx->room_id);
       ctx->notif_result = NULL;
-    } catch (KuzzleException e) {
+    } catch (kuzzleio::KuzzleException e) {
       BOOST_FAIL(e.what());
     }
   }

--- a/test/features/step_definitions/steps.hpp
+++ b/test/features/step_definitions/steps.hpp
@@ -18,39 +18,34 @@
 
 using cucumber::ScenarioScope;
 
-using namespace kuzzleio;
-using std::cout;
-using std::endl;
-using std::string;
-
 struct KuzzleCtx {
-  Kuzzle* kuzzle = nullptr;
-  Protocol* protocol = nullptr;
-  Options kuzzle_options;
+  kuzzleio::Kuzzle* kuzzle = nullptr;
+  kuzzleio::Protocol* protocol = nullptr;
+  kuzzleio::Options kuzzle_options;
 
-  string user_id;
-  string index;
-  string collection;
-  string jwt;
-  string document_id;
-  std::shared_ptr<SearchResult> search_result;
-  std::vector<std::shared_ptr<UserRight>> user_rights;
+  std::string user_id;
+  std::string index;
+  std::string collection;
+  std::string jwt;
+  std::string document_id;
+  std::shared_ptr<kuzzleio::SearchResult> search_result;
+  std::vector<std::shared_ptr<kuzzleio::UserRight>> user_rights;
 
-  string room_id;
+  std::string room_id;
 
-  User currentUser;
+  kuzzleio::User currentUser;
   json_spirit::Value_type customUserDataType = json_spirit::null_type;
 
   // 1 mean success, 0 failure and -1 is base state
   int success = -1;
-  string error_message;
+  std::string error_message;
   int hits = -1;
-  string content;
+  std::string content;
   // 1 mean yes, 0 no and -1 is base state
   int partial_exception = -1;
-  std::vector<string> string_array;
+  std::vector<std::string> string_array;
 
-  std::shared_ptr<notification_result> notif_result = nullptr;
+  std::shared_ptr<kuzzleio::notification_result> notif_result = nullptr;
 };
 
 class CustomNotificationListener {
@@ -62,7 +57,7 @@ class CustomNotificationListener {
       };
     };
   public:
-    NotificationListener listener;
+    kuzzleio::NotificationListener listener;
     static CustomNotificationListener* getSingleton() {
       static CustomNotificationListener* instance =
         new CustomNotificationListener();

--- a/test/features/step_definitions/steps.hpp
+++ b/test/features/step_definitions/steps.hpp
@@ -58,7 +58,6 @@ class CustomNotificationListener {
     CustomNotificationListener() {
       listener = [](std::shared_ptr<kuzzleio::notification_result> res) {
         ScenarioScope<KuzzleCtx> ctx;
-        std::cout << "received a notification: " << res->result->content << std::endl;
         ctx->notif_result = res;
       };
     };


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-c/pull/58

# Description

Some classes or functions are made available without having to access the kuzzleio namespace.
This is mainly because of [this line](https://github.com/kuzzleio/sdk-c/blob/1-dev/include/internal/sdk_wrappers_internal.h#L19) and because the current Cgo headers do not allow an easy way to isolate these functions in a namespace.

This PR:
* applies the related Cgo patch
* remove all global `using namespace` instructions in tests to prevent them from hiding namespacing problems (as was the case until this change)

# Boyscout

* use string litterals in tests 

# How to test

Simply play the example shown in our [C++ getting started page](https://docs.kuzzle.io/sdk-reference/cpp/1/getting-started/):

* without this PR: the example code compiles just fine :trollface: 
* with this PR, we get errors related to namespaces, such as:

```
error: unknown type name 'Kuzzle'; did you mean 'kuzzleio::Kuzzle'?
    Kuzzle *kuzzle = new kuzzleio::Kuzzle(new kuzzleio::WebSocket("kuzzle"));
```

(a documentation PR will obviously soon be submitted)

