### PR TITLE
Add missing getters about offline queue

### DIFF
--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -95,7 +95,7 @@ namespace kuzzleio {
 
       void connect();
 
-      std::string jwt() noexcept;
+      const std::string& jwt() const noexcept;
       void disconnect() noexcept;
       kuzzle_response* query(const kuzzle_request& request);
       kuzzle_response* query(
@@ -106,17 +106,17 @@ namespace kuzzleio {
       Kuzzle* startQueuing() noexcept;
       Kuzzle* stopQueuing() noexcept;
       Kuzzle* flushQueue() noexcept;
-      bool autoQueue() noexcept;
-      bool autoReconnect() noexcept;
-      bool autoResubscribe() noexcept;
-      bool autoReplay() noexcept;
-      int queueMaxSize() noexcept;
-      int queueTTL() noexcept;
-      int replayInterval() noexcept;
-      int reconnectionDelay() noexcept;
-      std::string volatiles() noexcept;
+      bool autoQueue() const noexcept;
+      bool autoReconnect() const noexcept;
+      bool autoResubscribe() const noexcept;
+      bool autoReplay() const noexcept;
+      int queueMaxSize() const noexcept;
+      int queueTTL() const noexcept;
+      int replayInterval() const noexcept;
+      int reconnectionDelay() const noexcept;
+      const std::string& volatiles() const noexcept;
       Kuzzle* volatiles(const std::string& volatiles) noexcept;
-      Protocol* getProtocol() noexcept;
+      Protocol* getProtocol() const noexcept;
 
       // event emitter overrides
       virtual KuzzleEventEmitter* addListener(

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -95,7 +95,7 @@ namespace kuzzleio {
 
       void connect();
 
-      std::string getJwt() noexcept;
+      std::string jwt() noexcept;
       void disconnect() noexcept;
       kuzzle_response* query(const kuzzle_request& request);
       kuzzle_response* query(

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -102,20 +102,20 @@ namespace kuzzleio {
           const kuzzle_request& request,
           const query_options& options);
       Kuzzle* playQueue() noexcept;
-      Kuzzle* setAutoReplay(bool autoReplay) noexcept;
+      Kuzzle* autoReplay(bool autoReplay) noexcept;
       Kuzzle* startQueuing() noexcept;
       Kuzzle* stopQueuing() noexcept;
       Kuzzle* flushQueue() noexcept;
-      bool isAutoQueue() noexcept;
-      bool isAutoReconnect() noexcept;
-      bool isAutoResubscribe() noexcept;
-      bool isAutoReplay() noexcept;
-      int getQueueMaxSize() noexcept;
-      int getQueueTTL() noexcept;
-      int getReplayInterval() noexcept;
-      int getReconnectionDelay() noexcept;
-      std::string getVolatile() noexcept;
-      Kuzzle* setVolatile(const std::string& volatiles) noexcept;
+      bool autoQueue() noexcept;
+      bool autoReconnect() noexcept;
+      bool autoResubscribe() noexcept;
+      bool autoReplay() noexcept;
+      int queueMaxSize() noexcept;
+      int queueTTL() noexcept;
+      int replayInterval() noexcept;
+      int reconnectionDelay() noexcept;
+      std::string volatiles() noexcept;
+      Kuzzle* volatiles(const std::string& volatiles) noexcept;
       Protocol* getProtocol() noexcept;
 
       // event emitter overrides

--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -106,6 +106,14 @@ namespace kuzzleio {
       Kuzzle* startQueuing() noexcept;
       Kuzzle* stopQueuing() noexcept;
       Kuzzle* flushQueue() noexcept;
+      bool isAutoQueue() noexcept;
+      bool isAutoReconnect() noexcept;
+      bool isAutoResubscribe() noexcept;
+      bool isAutoReplay() noexcept;
+      int getQueueMaxSize() noexcept;
+      int getQueueTTL() noexcept;
+      int getReplayInterval() noexcept;
+      int getReconnectionDelay() noexcept;
       std::string getVolatile() noexcept;
       Kuzzle* setVolatile(const std::string& volatiles) noexcept;
       Protocol* getProtocol() noexcept;

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -115,7 +115,7 @@ namespace kuzzleio {
     return std::string(kuzzle_get_volatile(_kuzzle));
   }
 
-  std::string Kuzzle::getJwt() noexcept {
+  std::string Kuzzle::jwt() noexcept {
     return std::string(kuzzle_get_jwt(_kuzzle));
   }
 

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -111,47 +111,47 @@ namespace kuzzleio {
     return this;
   }
 
-  std::string Kuzzle::volatiles() noexcept {
+  const std::string& Kuzzle::volatiles() const noexcept {
     return std::string(kuzzle_get_volatile(_kuzzle));
   }
 
-  std::string Kuzzle::jwt() noexcept {
+  const std::string& Kuzzle::jwt() const noexcept {
     return std::string(kuzzle_get_jwt(_kuzzle));
   }
 
-  Protocol* Kuzzle::getProtocol() noexcept {
+  Protocol* Kuzzle::getProtocol() const noexcept {
     return static_cast<Protocol*>(this->_protocol->instance);
   }
 
-  bool Kuzzle::autoQueue() noexcept {
+  bool Kuzzle::autoQueue() const noexcept {
     return kuzzle_get_auto_queue(_kuzzle);
   }
 
-  bool Kuzzle::autoReconnect() noexcept {
+  bool Kuzzle::autoReconnect() const noexcept {
     return kuzzle_get_auto_reconnect(_kuzzle);
   }
 
-  bool Kuzzle::autoResubscribe() noexcept {
+  bool Kuzzle::autoResubscribe() const noexcept {
     return kuzzle_get_auto_resubscribe(_kuzzle);
   }
 
-  bool Kuzzle::autoReplay() noexcept {
+  bool Kuzzle::autoReplay() const noexcept {
     return kuzzle_get_auto_replay(_kuzzle);
   }
 
-  int Kuzzle::queueMaxSize() noexcept {
+  int Kuzzle::queueMaxSize() const noexcept {
     return kuzzle_get_queue_max_size(_kuzzle);
   }
 
-  int Kuzzle::queueTTL() noexcept {
+  int Kuzzle::queueTTL() const noexcept {
     return kuzzle_get_queue_ttl(_kuzzle);
   }
 
-  int Kuzzle::replayInterval() noexcept {
+  int Kuzzle::replayInterval() const noexcept {
     return kuzzle_get_replay_interval(_kuzzle);
   }
 
-  int Kuzzle::reconnectionDelay() noexcept {
+  int Kuzzle::reconnectionDelay() const noexcept {
     return kuzzle_get_reconnection_delay(_kuzzle);
   }
 

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -86,7 +86,7 @@ namespace kuzzleio {
     return this;
   }
 
-  Kuzzle* Kuzzle::setAutoReplay(bool auto_replay) noexcept {
+  Kuzzle* Kuzzle::autoReplay(bool auto_replay) noexcept {
     kuzzle_set_auto_replay(_kuzzle, auto_replay);
     return this;
   }
@@ -106,12 +106,12 @@ namespace kuzzleio {
     return this;
   }
 
-  Kuzzle* Kuzzle::setVolatile(const std::string& volatile_data) noexcept {
+  Kuzzle* Kuzzle::volatiles(const std::string& volatile_data) noexcept {
     kuzzle_set_volatile(_kuzzle, const_cast<char*>(volatile_data.c_str()));
     return this;
   }
 
-  std::string Kuzzle::getVolatile() noexcept {
+  std::string Kuzzle::volatiles() noexcept {
     return std::string(kuzzle_get_volatile(_kuzzle));
   }
 
@@ -123,35 +123,35 @@ namespace kuzzleio {
     return static_cast<Protocol*>(this->_protocol->instance);
   }
 
-  bool Kuzzle::isAutoQueue() noexcept {
+  bool Kuzzle::autoQueue() noexcept {
     return kuzzle_get_auto_queue(_kuzzle);
   }
 
-  bool Kuzzle::isAutoReconnect() noexcept {
+  bool Kuzzle::autoReconnect() noexcept {
     return kuzzle_get_auto_reconnect(_kuzzle);
   }
 
-  bool Kuzzle::isAutoResubscribe() noexcept {
+  bool Kuzzle::autoResubscribe() noexcept {
     return kuzzle_get_auto_resubscribe(_kuzzle);
   }
 
-  bool Kuzzle::isAutoReplay() noexcept {
+  bool Kuzzle::autoReplay() noexcept {
     return kuzzle_get_auto_replay(_kuzzle);
   }
 
-  int Kuzzle::getQueueMaxSize() noexcept {
+  int Kuzzle::queueMaxSize() noexcept {
     return kuzzle_get_queue_max_size(_kuzzle);
   }
 
-  int Kuzzle::getQueueTTL() noexcept {
+  int Kuzzle::queueTTL() noexcept {
     return kuzzle_get_queue_ttl(_kuzzle);
   }
 
-  int Kuzzle::getReplayInterval() noexcept {
+  int Kuzzle::replayInterval() noexcept {
     return kuzzle_get_replay_interval(_kuzzle);
   }
 
-  int Kuzzle::getReconnectionDelay() noexcept {
+  int Kuzzle::reconnectionDelay() noexcept {
     return kuzzle_get_reconnection_delay(_kuzzle);
   }
 

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -123,6 +123,38 @@ namespace kuzzleio {
     return static_cast<Protocol*>(this->_protocol->instance);
   }
 
+  bool Kuzzle::isAutoQueue() noexcept {
+    return kuzzle_get_auto_queue(_kuzzle);
+  }
+
+  bool Kuzzle::isAutoReconnect() noexcept {
+    return kuzzle_get_auto_reconnect(_kuzzle);
+  }
+
+  bool Kuzzle::isAutoResubscribe() noexcept {
+    return kuzzle_get_auto_resubscribe(_kuzzle);
+  }
+
+  bool Kuzzle::isAutoReplay() noexcept {
+    return kuzzle_get_auto_replay(_kuzzle);
+  }
+
+  int Kuzzle::getQueueMaxSize() noexcept {
+    return kuzzle_get_queue_max_size(_kuzzle);
+  }
+
+  int Kuzzle::getQueueTTL() noexcept {
+    return kuzzle_get_queue_ttl(_kuzzle);
+  }
+
+  int Kuzzle::getReplayInterval() noexcept {
+    return kuzzle_get_replay_interval(_kuzzle);
+  }
+
+  int Kuzzle::getReconnectionDelay() noexcept {
+    return kuzzle_get_reconnection_delay(_kuzzle);
+  }
+
   KuzzleEventEmitter* Kuzzle::addListener(Event event,
     SharedEventListener listener) noexcept {
 


### PR DESCRIPTION
## What does this PR do ?

After putting the offline queue management from `Protocol` to `Kuzzle` we forgot to add some getters.
This PR add the following getters:

- bool autoQueue() const noexcept;
- bool autoReconnect() const noexcept;
- bool autoResubscribe() const noexcept;
- bool autoReplay() const noexcept;
- int queueMaxSize() const noexcept;
- int queueTTL() const noexcept;
- int replayInterval() const noexcept;
- int reconnectionDelay() const noexcept;

## Other

Changed getters name to follow proper C++ naming convention.