### PR TITLE
Add missing "isReady" protocol bridge

### DIFF
--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -39,8 +39,9 @@ namespace kuzzleio {
           const std::string& query, query_options * options,
           const std::string& requestId) = 0;
       virtual void close() = 0;
-      virtual int getState() =0 ;
+      virtual int getState() =0;
       virtual std::string getHost() = 0;
+      virtual bool isReady() =0;
 
       // to be overridden: though the NotificationListener storage is
       // handled by this class, you still need to send a subscribe request

--- a/include/protocol.hpp
+++ b/include/protocol.hpp
@@ -39,9 +39,9 @@ namespace kuzzleio {
           const std::string& query, query_options * options,
           const std::string& requestId) = 0;
       virtual void close() = 0;
-      virtual int getState() =0;
+      virtual int getState() = 0;
       virtual std::string getHost() = 0;
-      virtual bool isReady() =0;
+      virtual bool isReady() = 0;
 
       // to be overridden: though the NotificationListener storage is
       // handled by this class, you still need to send a subscribe request

--- a/include/websocket.hpp
+++ b/include/websocket.hpp
@@ -37,6 +37,7 @@ namespace kuzzleio {
       virtual void unregisterSub(const std::string&) override;
       virtual void cancelSubs() override;
       virtual std::string getHost() override;
+      virtual bool isReady() override;
 
       // Getters
       unsigned int getPort();

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -103,6 +103,10 @@ namespace kuzzleio {
     return static_cast<Protocol*>(_p)->getHost().c_str();
   }
 
+  bool bridge_cpp_is_ready(void *_p) {
+    return static_cast<Protocol*>(_p)->isReady();
+  }
+
   protocol* new_protocol_bridge(Protocol * cppProtocol) {
     protocol *p = new protocol();
 
@@ -121,6 +125,7 @@ namespace kuzzleio {
     p->cancel_subs = bridge_cpp_cancel_subs;
     p->remove_all_listeners = bridge_cpp_remove_all_listeners;
     p->get_host = bridge_cpp_get_host;
+    p->is_ready = bridge_cpp_is_ready;
 
     return p;
   }

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -161,4 +161,8 @@ namespace kuzzleio {
   bool WebSocket::isSslConnection() {
     return kuzzle_websocket_is_ssl_connection(this->_web_socket);
   }
+
+  bool WebSocket::isReady() {
+    return getState() == KUZZLE_STATE_CONNECTED;
+  }
 }


### PR DESCRIPTION
# Description

As the title says: a new protocol has been added recently in the Go and Cgo layers, but not in the C++ one. 

When invoking certain methods such as the Kuzzle `playQueue` one, a crash occurs because the Cgo layer tries to invoke the non-existant C++ bridge.

# How to test

Run the `playQueue` documentation test: it crashes without this fix, and it passes with it.
