### PR TITLE
Fix a memleak+crash from the jwt and volatiles getters

### DIFF
--- a/include/kuzzle.hpp
+++ b/include/kuzzle.hpp
@@ -95,7 +95,8 @@ namespace kuzzleio {
 
       void connect();
 
-      const std::string& jwt() const noexcept;
+      std::string jwt() const noexcept;
+      Kuzzle *jwt(const std::string& jwt) noexcept;
       void disconnect() noexcept;
       kuzzle_response* query(const kuzzle_request& request);
       kuzzle_response* query(
@@ -114,7 +115,7 @@ namespace kuzzleio {
       int queueTTL() const noexcept;
       int replayInterval() const noexcept;
       int reconnectionDelay() const noexcept;
-      const std::string& volatiles() const noexcept;
+      std::string volatiles() const noexcept;
       Kuzzle* volatiles(const std::string& volatiles) noexcept;
       Protocol* getProtocol() const noexcept;
 

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -15,7 +15,6 @@
 #include <exception>
 #include <stdexcept>
 #include <cstdlib>
-#include <cstring>
 
 #include "kuzzle.hpp"
 #include "internal/event_emitter.hpp"

--- a/src/kuzzle.cpp
+++ b/src/kuzzle.cpp
@@ -15,6 +15,7 @@
 #include <exception>
 #include <stdexcept>
 #include <cstdlib>
+#include <cstring>
 
 #include "kuzzle.hpp"
 #include "internal/event_emitter.hpp"
@@ -111,12 +112,27 @@ namespace kuzzleio {
     return this;
   }
 
-  const std::string& Kuzzle::volatiles() const noexcept {
-    return std::string(kuzzle_get_volatile(_kuzzle));
+  std::string Kuzzle::volatiles() const noexcept {
+    char *volatiles = kuzzle_get_volatile(_kuzzle);
+    std::string volatilestr = volatiles;
+
+    free(volatiles);
+
+    return volatilestr;
   }
 
-  const std::string& Kuzzle::jwt() const noexcept {
-    return std::string(kuzzle_get_jwt(_kuzzle));
+  std::string Kuzzle::jwt() const noexcept {
+    char *jwt = kuzzle_get_jwt(_kuzzle);
+    std::string jwtstr = jwt;
+
+    free(jwt);
+
+    return jwtstr;
+  }
+
+  Kuzzle *Kuzzle::jwt(const std::string &jwt) noexcept {
+    kuzzle_set_jwt(_kuzzle, const_cast<char*>(jwt.c_str()));
+    return this;
   }
 
   Protocol* Kuzzle::getProtocol() const noexcept {


### PR DESCRIPTION
# Description

* the `jwt` and `volatiles` getters in the Kuzzle object returned constant references of temporary variables, which makes the SDK crash whenever we try to access them
* these getters are wrappers for the cgo getters, which allocate memory on the heap: there was a memleak since the memory was never freed
* signature change: because of the 2 points above, these 2 getters either cannot be const, or they cannot return a const reference. I chose to drop the latter: it seems more important to me that getters claim to not change the state of a class, even if it means returning a new string instance every time they are called
* the `jwt` setter was missing

